### PR TITLE
Update citation and button style

### DIFF
--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -110,7 +110,7 @@ iframe {
 .pure-button {
     background-color: #1f8dd6;
     color: white;
-    padding: 0.4em 1em;
+    padding: 0.5em 1.3em;
     border-radius: 5px;
 }
 
@@ -118,12 +118,18 @@ a.pure-button-primary {
     background: white;
     color: #1f8dd6;
     border-radius: 5px;
-    font-size: 150%;
+    font-size: 130%;
     font-weight: 500;
     border: 2px solid #1871ab;
     &:hover {
         text-decoration: none;
     }
+}
+
+a.pure-button-secondary {
+    margin-top: 1em;
+    font-size: 120%;
+    font-weight: 500;
 }
 
 .doc-content {
@@ -224,7 +230,7 @@ a.pure-button-primary {
 
         li {
             list-style: none;
-            
+
             a {
                 font-size: 14px;
                 color: #333;
@@ -299,6 +305,13 @@ a.pure-button-primary {
     font-size: 120%;
 }
 
+.citation {
+    position: absolute;
+    right: 10px;
+    bottom: 5px;
+    font-size: 80%;
+    color: #eee;
+}
 
 /*
  * -- CONTENT STYLES --

--- a/components/Home.jsx
+++ b/components/Home.jsx
@@ -22,17 +22,20 @@ var Component = React.createClass({
                             <NavLink className="pure-button pure-button-primary" routeName="docs" navParams={{key: 'quick-start'}} context={this.props.context}>Get Started</NavLink>
                         </p>
                     </div>
+                    <div className="citation">
+                        <cite>
+                            <a href="https://www.flickr.com/photos/devinmoore/2670474853" title="Splash derived from Blue Ring Electricity Fractal by Devin Moore used under CC BY 2.0" _target="blank">Citation</a>
+                        </cite>
+                    </div>
                 </div>
+
                 <div className="content">
                     <Doc content={this.props.content} context={this.props.context} />
                 </div>
 
                 <div className="is-center">
-                    <NavLink className="pure-button pure-button-primary" routeName="docs" navParams={{key: 'quick-start'}} context={this.props.context}>Get Started</NavLink>
+                    <NavLink className="pure-button pure-button-secondary" routeName="docs" navParams={{key: 'quick-start'}} context={this.props.context}>Get Started</NavLink>
                 </div>
-                <hr/>
-
-                <div className="is-center"><cite>Splash derived from <a href="https://www.flickr.com/photos/devinmoore/2670474853" target="_blank">Blue Ring Electricity Fractal</a> by <a href="https://www.flickr.com/photos/devinmoore/" target="_blank">Devin Moore</a> used under <a href="http://creativecommons.org/licenses/by/2.0/" target="_blank">CC BY 2.0</a></cite></div>
             </section>
         );
     }


### PR DESCRIPTION
@jedireza @mridgway 

- This moves the citation to a link in the splash and moves the text to a tooltip. I'm not sold on positioning but I like that it doesn't take over the bottom of the page.
- I switched the bottom Get Started button to the pure secondary button, which looks better on white.

![fluxible_stylez](https://cloud.githubusercontent.com/assets/193272/5920038/5271be12-a5ee-11e4-9e60-ed5f9e170fb5.png)
