### PR TITLE
Fix edit on github links and support off site links

### DIFF
--- a/components/Doc.jsx
+++ b/components/Doc.jsx
@@ -61,4 +61,9 @@ Doc.contextTypes = {
     executeAction: React.PropTypes.func
 };
 
+Doc.propTypes = {
+    currentDoc: React.PropTypes.object.isRequired,
+    currentRoute: React.PropTypes.object.isRequired
+};
+
 export default Doc;

--- a/components/Docs.jsx
+++ b/components/Docs.jsx
@@ -42,12 +42,17 @@ class Docs extends React.Component {
                     <b className="hidden">Toggle the menu</b>
                 </button>
                 <Menu selected={this.props.currentRoute && this.props.currentRoute.get('name')} onClickEvent={this.hideMenu.bind(this)} />
-                <Doc currentDoc={this.props.currentDoc} />
+                <Doc currentDoc={this.props.currentDoc} currentRoute={this.props.currentRoute} />
                 <div id="overlay" className="D-n Z-3 Pos-f T-0 Start-0 W-100% H-100%"></div>
             </div>
         );
     }
 }
+
+Docs.propTypes = {
+    currentDoc: React.PropTypes.object.isRequired,
+    currentRoute: React.PropTypes.object.isRequired
+};
 
 // wrap with route handler
 Docs = handleRoute(Docs);

--- a/components/Menu.jsx
+++ b/components/Menu.jsx
@@ -24,7 +24,15 @@ class Menu extends React.Component {
                 let classList = cx({
                     'selected': self.props.selected === link.routeName
                 });
-                submenu.push(<li key={link.label} className={classList}><NavLink className={link.label + ' D-b Td-n:h Py-5px'} routeName={link.routeName}>{link.label}</NavLink></li>);
+
+                let linkNode = (<NavLink className={link.label + ' D-b Td-n:h Py-5px'} routeName={link.routeName}>{link.label}</NavLink>);
+
+                // support off site links
+                if (link.url) {
+                    linkNode = (<NavLink className={link.label + ' D-b Td-n:h Py-5px'} href={link.url}>{link.label}</NavLink>);
+                }
+
+                submenu.push(<li key={link.label} className={classList}>{linkNode}</li>);
             });
 
             if (submenu.length) {

--- a/configs/menu.js
+++ b/configs/menu.js
@@ -80,6 +80,10 @@ export default [
             {
                 label: 'Data Services',
                 routeName: 'dataServices'
+            },
+            {
+                label: 'Routing',
+                url: 'https://github.com/yahoo/fluxible-router#fluxible-router'
             }
         ]
     },


### PR DESCRIPTION
@mridgway @jedireza 

Looks like the Edit on Github link was lost in the refactor. Also, added Routing to the guide section which points to the readme for now. Wanted to have something that pointed to the new library.