### PR TITLE
Add client side search capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.jshintignore
 .sass-cache
+.validate.json
 artifacts
 assets.js
 build

--- a/actions/doSearch.js
+++ b/actions/doSearch.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+import Debug from 'debug';
+const debug = Debug('doSearch');
+
+export default function doSearch(context, query, done) {
+    debug(query);
+    context.dispatch('DO_SEARCH', query);
+    done();
+}

--- a/actions/loadIndex.js
+++ b/actions/loadIndex.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+import Debug from 'debug';
+const debug = Debug('loadIndex');
+
+export default function loadIndex(context, payload, done) {
+    debug(payload);
+
+    // Load from service
+    context.service.read('search', {}, {}, function (err, data) {
+        debug('get index from service');
+        context.dispatch('RECEIVE_INDEX', data);
+        done();
+    });
+}

--- a/actions/showSearch.js
+++ b/actions/showSearch.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+import Debug from 'debug';
+const debug = Debug('showSearch');
+
+export default function (context, route, done) {
+    debug('show search page');
+    context.dispatch('DO_SEARCH', route.get('query').get('q'));
+    done();
+}

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ import fetchrPlugin from 'fluxible-plugin-fetchr';
 import routes from './configs/routes';
 import Application from './components/Application.jsx';
 import DocStore from './stores/DocStore';
+import SearchStore from './stores/SearchStore';
 import { RouteStore } from 'fluxible-router';
 
 const debug = Debug('app.js');
@@ -36,5 +37,6 @@ app.plug(fetchrPlugin({ xhrPath: '/_api' }));
 
 app.registerStore(DocStore);
 app.registerStore(MyRouteStore);
+app.registerStore(SearchStore);
 
 export default app;

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -82,6 +82,10 @@
     opacity: 1;
 }
 
+#navigation form {
+    transition: width 0.2s ease-in;
+}
+
 /**
  * .selected list item
  */

--- a/assets/css/mq.css
+++ b/assets/css/mq.css
@@ -11,9 +11,18 @@
         width: 100% !important;
     }
 
-    #navigation,
+    #navigation .navLink,
     .edit-github {
         display: none;
+    }
+
+    #atomic #navigation form {
+        right: 40px;
+    }
+
+    #navigation .fa-search {
+        margin-right: 20px;
+        font-size: 23px;
     }
 
     /**

--- a/client.js
+++ b/client.js
@@ -6,11 +6,13 @@
 
 import React from 'react';
 import app from './app';
+import Debug from 'debug';
 const dehydratedState = window.App; // sent from the server
 
 // for chrome dev tool support
 window.React = React;
 window.app = app;
+window.fluxibleDebug = Debug;
 
 app.rehydrate(dehydratedState, function (err, context) {
     if (err) {

--- a/components/Application.jsx
+++ b/components/Application.jsx
@@ -65,7 +65,7 @@ class Application extends React.Component {
                         <div className="innerwrapper spaceBetween Mx-a--sm W-90%--sm W-a--sm">
                             <NavLink className={logoClasses} routeName="home" style={{ fontFamily: 'Montserrat' }}>
                                 <img src="/public/images/logo_small.svg" width="16" height="16" alt="Fluxible" style={{verticalAlign: 'baseline'}} /> Fluxible
-                            </NavLink> <TopNav selected={routeName} />
+                            </NavLink> <TopNav selected={routeName} currentRoute={this.props.currentRoute} />
                         </div>
                     </div>
                     {Handler}

--- a/components/Docs.jsx
+++ b/components/Docs.jsx
@@ -6,8 +6,11 @@
 import React from 'react';
 import Menu from './Menu.jsx';
 import Doc from './Doc.jsx';
+import SearchResults from './SearchResults.jsx';
 import cx from 'classnames';
 import { handleRoute } from 'fluxible-router';
+import connectToStores from 'fluxible/addons/connectToStores';
+import SearchStore from '../stores/SearchStore';
 
 class Docs extends React.Component {
     constructor(props, context) {
@@ -34,15 +37,28 @@ class Docs extends React.Component {
             'menu-on': this.state.isMenuVisible,
             'docs-page innerwrapper D-tb--sm Tbl-f Pt-20px Mb-50px Mx-a--sm W-90%--sm': true
         });
+        let page;
+        const currentRoute = this.props.currentRoute;
+
+        if ('search' === currentRoute.get('name')) {
+            page = (<SearchResults results={this.props.search.results} currentRoute={currentRoute} />);
+        } else {
+            page = (<Doc currentDoc={this.props.currentDoc} currentRoute={currentRoute} />);
+        }
 
         return (
             <div id="docs" className={wrapperClasses}>
-                <button onClick={this.handleMenuToggle.bind(this)} id="toggleMenuButton" className="menu-button D-n--sm Pos-a resetButton End-0 Z-7 Mend-10px">
+                <button
+                    onClick={this.handleMenuToggle.bind(this)}
+                    id="toggleMenuButton"
+                    className="menu-button D-n--sm Pos-a resetButton End-0 Z-7 Mend-10px"
+                    style={{ top: "-12px" }}
+                >
                     <i className="fa fa-bars"></i>
                     <b className="hidden">Toggle the menu</b>
                 </button>
                 <Menu selected={this.props.currentRoute && this.props.currentRoute.get('name')} onClickEvent={this.hideMenu.bind(this)} />
-                <Doc currentDoc={this.props.currentDoc} currentRoute={this.props.currentRoute} />
+                {page}
                 <div id="overlay" className="D-n Z-3 Pos-f T-0 Start-0 W-100% H-100%"></div>
             </div>
         );
@@ -53,6 +69,12 @@ Docs.propTypes = {
     currentDoc: React.PropTypes.object.isRequired,
     currentRoute: React.PropTypes.object.isRequired
 };
+
+Docs = connectToStores(Docs, [ SearchStore ], function (stores, props) {
+    return {
+        search: stores.SearchStore.getState()
+    };
+});
 
 // wrap with route handler
 Docs = handleRoute(Docs);

--- a/components/Home.jsx
+++ b/components/Home.jsx
@@ -39,8 +39,8 @@ class Home extends React.Component {
 
                     <div className="Bxz-bb D-ib Va-t W-100% Pstart-20px--sm W-50%--sm">
                         <h2>Dehydration/Rehydration</h2>
-                        <p><NavLink routeName="stores">Stores</NavLink> can provide `dehydrate` and `rehydrate` so
-                        that you can propagate the initial server state to the client.</p>
+                        <p><NavLink routeName="stores">Stores</NavLink> can provide `dehydrate` and `rehydrate`
+                        methods so that you can propagate the initial server state to the client.</p>
                     </div>
 
                     <div className="Bxz-bb D-ib Va-t W-100% Pend-20px--sm W-50%--sm Bdt-1--sm Mt-2em--sm">

--- a/components/Search.jsx
+++ b/components/Search.jsx
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+import React from 'react';
+import cx from 'classnames';
+import { navigateAction, RouteStore } from 'fluxible-router';
+import connectToStores from 'fluxible/addons/connectToStores';
+import loadIndex from '../actions/loadIndex';
+import SearchStore from '../stores/SearchStore';
+import Debug from 'debug';
+const debug = Debug('Search');
+const ENTER_KEY_CODE = 13;
+
+class Search extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            visible: false
+        };
+    }
+
+    componentDidMount() {
+        this.context.executeAction(loadIndex);
+
+        // if on search page with query, then set state
+        const query = this.props.currentRoute.get('query').get('q');
+        if (query) {
+            this.setState({
+                visible: true
+            });
+        }
+    }
+
+    componentDidUpdate() {
+        const el = React.findDOMNode(this.refs.q);
+
+        // ensure input is focused
+        if (this.state.visible) {
+            el.focus();
+        }
+
+        // set input to query if present
+        const query = this.context.getStore(SearchStore).getQuery();
+        if (query) {
+            el.value = query;
+        }
+    }
+
+    _toggleSearchVisibility() {
+        this.setState({
+            visible: !this.state.visible
+        });
+    }
+
+    _getPath() {
+        return this.context.getStore(RouteStore).makePath('search');
+    }
+
+    _onKeyDown(event) {
+        if (event.keyCode === ENTER_KEY_CODE) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            this.context.executeAction(navigateAction, {
+                method: 'GET',
+                url: this._getPath() + '?q=' + event.target.value
+            });
+        }
+    }
+
+    render() {
+        let classes = cx({
+            'D-ib Mstart-3px Ov-h Va-m Pos-a End-20px': true,
+            'W-0': this.state.visible === false,
+            'W-200px Ov-a': this.state.visible
+        });
+        return (
+            <div className="D-ib">
+                <form className={classes}>
+                    <input
+                        ref="q"
+                        type="text"
+                        name="q"
+                        onKeyDown={this._onKeyDown.bind(this)}
+                        className="Px-4px Py-1px Bdrs-2px Bd-2 C-#fff Fw-b"
+                    />
+                </form>
+                <i className="Va-m Pos-r fa fa-search Cur-p" onClick={this._toggleSearchVisibility.bind(this)}></i>
+            </div>
+        );
+    }
+}
+
+Search.contextTypes = {
+    executeAction: React.PropTypes.func,
+    getStore: React.PropTypes.func
+};
+
+Search.propTypes = {
+    currentRoute: React.PropTypes.object
+};
+
+Search = connectToStores(Search, [ SearchStore ], function (stores, props) {
+    return {
+        search: stores.SearchStore.getState()
+    };
+});
+
+export default Search;

--- a/components/SearchResults.jsx
+++ b/components/SearchResults.jsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+import React from 'react';
+import { NavLink } from 'fluxible-router';
+import doSearch from '../actions/doSearch';
+import SearchStore from '../stores/SearchStore';
+
+class SearchResults extends React.Component {
+    componentDidUpdate() {
+        // this handles performing a search when deep linking to search page
+        const query = this.props.currentRoute.get('query').get('q');
+        const storeQuery = this.context.getStore(SearchStore).getQuery();
+        if (query && query !== storeQuery) {
+            this.context.executeAction(doSearch, query);
+        }
+    }
+
+    showResults() {
+        let html = (<p>No results found</p>);
+        const results = this.props.results.map(result => {
+            return (
+                <li key={result.id}>
+                    <h3>
+                        <NavLink href={result.permalink}>{result.title}</NavLink>
+                    </h3>
+                    <p className="M-0">{result.description}</p>
+                    <small className="C-#006621">{result.permalink}</small>
+                </li>
+            );
+        });
+
+        if (results.length) {
+            html = (<ol className="List-dc">{results}</ol>);
+        }
+
+        return html;
+    }
+
+    render() {
+        return (
+            <div id="main" role="main" className="D-tbc--sm Px-10px Pos-r">
+                <h1>Search Results</h1>
+                {this.showResults()}
+            </div>
+        );
+    }
+}
+
+SearchResults.contextTypes = {
+    executeAction: React.PropTypes.func,
+    getStore: React.PropTypes.func
+};
+
+SearchResults.propTypes = {
+    currentRoute: React.PropTypes.object.isRequired,
+    results: React.PropTypes.array
+};
+
+export default SearchResults;

--- a/components/TopNav.jsx
+++ b/components/TopNav.jsx
@@ -6,20 +6,28 @@
 import React from 'react';
 import { NavLink } from 'fluxible-router';
 import cx from 'classnames';
+import Search from './Search.jsx'
 
 class TopNav extends React.Component {
+    constructor() {
+        super();
+    }
+
     render() {
-        let selected = this.props.selected;
+        const selected = this.props.selected;
 
         return (
             <ul id="navigation" role="navigation" className="Va-m reset">
-                <li className={cx({'selected': selected !== 'home', 'D-ib Va-m Pos-r Fw-400': true})}>
+                <li className="D-ib Va-m Pos-r Fw-400 C-#fff Td-n:h">
+                    <Search currentRoute={this.props.currentRoute} />
+                </li>
+                <li className={cx({'selected': selected !== 'home', 'D-ib Va-m Mstart-20px Pos-r Fw-400 navLink': true})}>
                     <NavLink routeName="quickStart" className="D-b C-#fff Td-n:h">
                         Docs
                     </NavLink>
                 </li>
                 <li className="D-ib Va-m Mstart-20px Pos-r Fw-400">
-                    <a href="https://github.com/yahoo/fluxible" className="D-b C-#fff Td-n:h" target="_blank">
+                    <a href="https://github.com/yahoo/fluxible" className="D-b C-#fff Td-n:h navLink" target="_blank">
                         <i className="Va-m Pos-r fa fa-github"></i> GitHub
                     </a>
                 </li>
@@ -27,5 +35,10 @@ class TopNav extends React.Component {
         );
     }
 }
+
+TopNav.propTypes = {
+    currentRoute: React.PropTypes.object,
+    selected: React.PropTypes.string
+};
 
 export default TopNav;

--- a/configs/routes.js
+++ b/configs/routes.js
@@ -4,6 +4,7 @@
  */
 
 import showDoc from '../actions/showDoc';
+import showSearch from '../actions/showSearch';
 import demoException from '../actions/demoException';
 import Home from '../components/Home.jsx';
 import Docs from '../components/Docs.jsx';
@@ -17,7 +18,8 @@ export default {
         handler: Home,
         githubPath: '/docs/home.md',
         action: showDoc,
-        pageTitle: 'Fluxible | A Pluggable Container for Isomorphic Flux Applications'
+        pageTitle: 'Fluxible | A Pluggable Container for Isomorphic Flux Applications',
+        pageDescription: 'A Pluggable Container for Isomorphic Flux Applications'
     },
     quickStart: {
         path: '/quick-start.html',
@@ -25,7 +27,8 @@ export default {
         handler: Docs,
         githubPath: '/docs/quick-start.md',
         action: showDoc,
-        pageTitlePrefix: 'Quick Start'
+        pageTitlePrefix: 'Quick Start',
+        pageDescription: 'Get started with Fluxible by using our generator to setup your application.'
     },
     faq: {
         path: '/faq.html',
@@ -33,7 +36,15 @@ export default {
         handler: Docs,
         githubPath: '/docs/faq.md',
         action: showDoc,
-        pageTitlePrefix: 'FAQ'
+        pageTitlePrefix: 'FAQ',
+        pageDescription: 'Frequently asked questions from the community.'
+    },
+    search: {
+        path: '/search.html',
+        method: 'GET',
+        handler: Docs,
+        action: showSearch,
+        pageTitlePrefix: 'Search'
     },
     demo500: {
         path: '/demo-err-500.html',
@@ -49,7 +60,8 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/Actions.md',
         action: showDoc,
-        pageTitlePrefix: 'API: Actions'
+        pageTitlePrefix: 'API: Actions',
+        pageDescription: 'Actions (called "action creators" in Flux) in Fluxible are stateless async functions.'
     },
     components: {
         path: '/api/components.html',
@@ -57,7 +69,9 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/Components.md',
         action: showDoc,
-        pageTitlePrefix: 'API: Components'
+        pageTitlePrefix: 'API: Components',
+        pageDescription: 'React components able to access the state of the application that is held within stores ' +
+            'and also be able to execute actions that the stores can react to.'
     },
     fluxible: {
         path: '/api/fluxible.html',
@@ -65,7 +79,9 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/Fluxible.md',
         action: showDoc,
-        pageTitlePrefix: 'API: Fluxible'
+        pageTitlePrefix: 'API: Fluxible',
+        pageDescription: 'Instantiated once for your application, this holds settings and interfaces' +
+            ' that are used across all requests.'
     },
     fluxibleContext: {
         path: '/api/fluxible-context.html',
@@ -73,7 +89,9 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/FluxibleContext.md',
         action: showDoc,
-        pageTitlePrefix: 'API: FluxibleContext'
+        pageTitlePrefix: 'API: FluxibleContext',
+        pageDescription: 'Instantiated once per request/session, this container provides isolation of ' +
+            'stores, dispatches, and other data so that it is not shared between requests on the server side.'
     },
     plugins: {
         path: '/api/plugins.html',
@@ -81,7 +99,8 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/Plugins.md',
         action: showDoc,
-        pageTitlePrefix: 'API: Plugins'
+        pageTitlePrefix: 'API: Plugins',
+        pageDescription: 'Plugins allow you to extend the interface of each context type.'
     },
     stores: {
         path: '/api/stores.html',
@@ -89,7 +108,9 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/Stores.md',
         action: showDoc,
-        pageTitlePrefix: 'API: Stores'
+        pageTitlePrefix: 'API: Stores',
+        pageDescription: 'Flux stores are where you keep your application\'s state and ' +
+            'handle business logic that reacts to data events. '
     },
 
     // Addons
@@ -99,7 +120,8 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/addons/BaseStore.md',
         action: showDoc,
-        pageTitlePrefix: 'API: addons/BaseStore'
+        pageTitlePrefix: 'API: addons/BaseStore',
+        pageDescription: 'A base class that you can extend to reduce boilerplate when creating stores.'
     },
     fluxibleComponent: {
         path: '/api/addons/FluxibleComponent.html',
@@ -107,7 +129,10 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/addons/FluxibleComponent.md',
         action: showDoc,
-        pageTitlePrefix: 'API: addons/FluxibleComponent'
+        pageTitlePrefix: 'API: addons/FluxibleComponent',
+        pageDescription: 'The FluxibleComponent is a wrapper component that will provide all' +
+            ' of its children with access to the Fluxible component context via React\'s' +
+            ' childContextTypes and getChildContext.'
     },
     fluxibleMixin: {
         path: '/api/addons/FluxibleMixin.html',
@@ -115,7 +140,8 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/addons/FluxibleMixin.md',
         action: showDoc,
-        pageTitlePrefix: 'API: addons/FluxibleMixin'
+        pageTitlePrefix: 'API: addons/FluxibleMixin',
+        pageDescription: 'The mixin will add the contextTypes getStore and executeAction to your component.'
     },
     connectToStores: {
         path: '/api/addons/connectToStores.html',
@@ -123,7 +149,9 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/addons/connectToStores.md',
         action: showDoc,
-        pageTitlePrefix: 'API: addons/connectToStores'
+        pageTitlePrefix: 'API: addons/connectToStores',
+        pageDescription: 'connectToStores is a higher-order component that provides a convenient way' +
+            ' to access state from the stores from within your component'
     },
     createStore: {
         path: '/api/addons/createStore.html',
@@ -131,7 +159,9 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/addons/createStore.md',
         action: showDoc,
-        pageTitlePrefix: 'API: addons/createStore'
+        pageTitlePrefix: 'API: addons/createStore',
+        pageDescription: 'A helper method similar to React.createClass but for creating stores that' +
+            ' extend BaseStore. Also supports mixins.'
     },
     provideContext: {
         path: '/api/addons/provideContext.html',
@@ -139,7 +169,9 @@ export default {
         handler: Docs,
         githubPath: '/docs/api/addons/provideContext.md',
         action: showDoc,
-        pageTitlePrefix: 'API: addons/provideContext'
+        pageTitlePrefix: 'API: addons/provideContext',
+        pageDescription: 'provideContext wraps the Component with a higher-order component' +
+            ' that specifies the child context for you.'
     },
 
     // Tutorials
@@ -149,7 +181,9 @@ export default {
         handler: Docs,
         githubPath: '/docs/tutorials/routing.md',
         action: showDoc,
-        pageTitlePrefix: 'Routing Tutorial'
+        pageTitlePrefix: 'Routing Tutorial',
+        pageDescription: 'A tutorial covering the concepts of building an isomorphic website' +
+            ' with Fluxible that demonstrates routing.'
     },
     isomorphicFlux: {
         path: '/api/bringing-flux-to-the-server.html',
@@ -157,7 +191,8 @@ export default {
         handler: Docs,
         githubPath: '/docs/guides/bringing-flux-to-the-server.md',
         action: showDoc,
-        pageTitlePrefix: 'Bringing Flux to the Server'
+        pageTitlePrefix: 'Bringing Flux to the Server',
+        pageDescription: 'An in depth look at how Flux was brought to the server.'
     },
 
     // Guides
@@ -167,7 +202,9 @@ export default {
         handler: Docs,
         githubPath: '/docs/guides/data-services.md',
         action: showDoc,
-        pageTitlePrefix: 'Data Services Guide'
+        pageTitlePrefix: 'Data Services Guide',
+        pageDescription: 'Services are where you define your CRUD operations for a' +
+            ' specific resource. A resource is a unique string that identifies the data.'
     },
 
     // Community
@@ -177,7 +214,8 @@ export default {
         handler: Docs,
         githubPath: '/docs/community/libraries.md',
         action: showDoc,
-        pageTitlePrefix: 'Community Libraries'
+        pageTitlePrefix: 'Community Libraries',
+        pageDescription: 'Take a look at some of the libraries that our community has built.'
     },
     presentations: {
         path: '/community/presentations.html',
@@ -185,7 +223,8 @@ export default {
         handler: Docs,
         githubPath: '/docs/community/presentations.md',
         action: showDoc,
-        pageTitlePrefix: 'Community Presentations'
+        pageTitlePrefix: 'Community Presentations',
+        pageDescription: 'Presentations we have given to the community.'
     },
     referenceApplications: {
         path: '/community/reference-applications.html',
@@ -193,7 +232,8 @@ export default {
         handler: Docs,
         githubPath: '/docs/community/reference-applications.md',
         action: showDoc,
-        pageTitlePrefix: 'Community Reference Applications'
+        pageTitlePrefix: 'Community Reference Applications',
+        pageDescription: 'Applications using Fluxible in the wild.'
     },
     status404: {
         path: '/__http404',

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     }
   },
   "dependencies": {
+    "async": "^1.0.0",
     "babel": "^5.1.11",
     "body-parser": "^1.6.4",
     "classnames": "^1.1.4",
@@ -53,6 +54,7 @@
     "fluxible-router": "^0.1.2",
     "highlight.js": "^8.4.0",
     "immutable": "^3.7.2",
+    "lunr": "^0.5.9",
     "marked": "^0.3.3",
     "react": "^0.13.0",
     "serialize-javascript": "^1.0.0",

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ import html from './components/Html.jsx';
 import tracking from './configs/tracking';
 import assets from './utils/assets';
 import DocsService from './services/docs';
+import SearchService from './services/search';
 
 const HtmlComponent = React.createFactory(html);
 const server = express();
@@ -32,6 +33,7 @@ const fetchrPlugin = app.getPlugin('FetchrPlugin');
 
 // Register our services
 fetchrPlugin.registerService(DocsService);
+fetchrPlugin.registerService(SearchService);
 
 // Set up the fetchr middleware
 server.use(fetchrPlugin.getXhrPath(), fetchrPlugin.getMiddleware());

--- a/services/search.js
+++ b/services/search.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+import Debug from 'debug';
+const debug = Debug('SearchService');
+
+export default {
+    name: 'search',
+    read: function (req, resource, params, config, callback) {
+        debug('Reading index');
+        const index = require('../build/search.json');
+        debug('Index loaded');
+        return callback(null, index);
+    }
+};

--- a/stores/SearchStore.js
+++ b/stores/SearchStore.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+import Debug from 'debug';
+import { BaseStore } from 'fluxible/addons';
+import lunr from 'lunr';
+
+const debug = Debug('SearchStore');
+
+class SearchStore extends BaseStore {
+    constructor(dispatcher) {
+        super();
+
+        this.docs = null;
+        this.index = null;
+        this.query = null;
+        this.results = [];
+    }
+
+    _receiveIndex(payload) {
+        debug('Receive index', payload);
+        this.docs = payload.docs.reduce((obj, doc) => {
+            obj[doc.id] = doc;
+            return obj;
+        }, {});
+        this.index = lunr.Index.load(payload.index);
+        this.emitChange();
+    }
+
+    _doSearch(query) {
+        debug('Seaching');
+        this.query = query;
+        if (this.index) {
+            // perform search, grab each doc and only return first 10
+            this.results = this.index.search(query).map(result => this.docs[result.ref]).slice(0, 10);
+            debug('Search complete');
+        }
+        this.emitChange();
+    }
+
+    getDocs() {
+        return this.docs;
+    }
+
+    getIndex() {
+        return this.index;
+    }
+
+    getQuery() {
+        return this.query;
+    }
+
+    getState() {
+        return {
+            docs: this.docs,
+            index: this.index,
+            query: this.query,
+            results: this.results
+        };
+    }
+}
+
+SearchStore.storeName = 'SearchStore';
+
+SearchStore.handlers = {
+    'RECEIVE_INDEX': '_receiveIndex',
+    'DO_SEARCH': '_doSearch'
+};
+
+export default SearchStore;

--- a/tests/fixtures/index.json
+++ b/tests/fixtures/index.json
@@ -1,0 +1,2539 @@
+{
+    "docs": [
+        {
+            "id": "/docs/home.md",
+            "title": "Fluxible | A Pluggable Container for Isomorphic Flux Applications",
+            "body": "<h1><a name=\"features\" class=\"anchor\"></a>Features <a href=\"#features\" class=\"hash-link\">#</a></h1><h2><a name=\"singleton-free-for-server-rendering\" class=\"anchor\"></a>Singleton-free for server rendering <a href=\"#singleton-free-for-server-rendering\" class=\"hash-link\">#</a></h2><p><a href=\"/api/stores.html\">Stores</a> are classes that are instantiated per request or client session. This ensures that the stores are isolated and do not bleed information between requests.</p>\n<h2><a name=\"dehydration-rehydration\" class=\"anchor\"></a>Dehydration/Rehydration <a href=\"#dehydration-rehydration\" class=\"hash-link\">#</a></h2><p><a href=\"/api/stores.html\">Stores</a> can provide <code>dehydrate</code> and <code>rehydrate</code> so that you can propagate the initial server state to the client.</p>\n<h2><a name=\"react-integration\" class=\"anchor\"></a>React Integration <a href=\"#react-integration\" class=\"hash-link\">#</a></h2><p>Helper utilities for integrating your Fluxible app into React <a href=\"/api/components.html\">components</a> with less boilerplate.</p>\n<h2><a name=\"flow-regulation\" class=\"anchor\"></a>Flow Regulation <a href=\"#flow-regulation\" class=\"hash-link\">#</a></h2><p><a href=\"/api/fluxible-context.html\">FluxibleContext</a> restricts access to your Flux methods so that you can&#39;t break out of the unidirectional flow.</p>\n<h2><a name=\"pluggable\" class=\"anchor\"></a>Pluggable <a href=\"#pluggable\" class=\"hash-link\">#</a></h2><p>Want to add your own interfaces to the Flux flow? <a href=\"/api/plugins.html\">Plugins</a> allow you to add methods to any of the contexts.</p>\n<h2><a name=\"updated-for-react-0-13\" class=\"anchor\"></a>Updated for React 0.13 <a href=\"#updated-for-react-0-13\" class=\"hash-link\">#</a></h2><p>Updated to follow React 0.13&#39;s changes and the deprecations coming in the next version of React.</p>\n",
+            "description": "A Pluggable Container for Isomorphic Flux Applications",
+            "permalink": "/"
+        }
+    ],
+    "index": {
+        "version": "0.5.9",
+        "fields": [
+            {
+                "name": "title",
+                "boost": 10
+            },
+            {
+                "name": "description",
+                "boost": 5
+            },
+            {
+                "name": "body",
+                "boost": 1
+            },
+            {
+                "name": "permalink",
+                "boost": 1
+            }
+        ],
+        "ref": "id",
+        "documentStore": {
+            "store": {
+                "/docs/home.md": [
+                    "0",
+                    "0.13",
+                    "0.13&#39;",
+                    "13",
+                    "access",
+                    "add",
+                    "allow",
+                    "app",
+                    "applic",
+                    "between",
+                    "bleed",
+                    "boilerplate.</p",
+                    "break",
+                    "can&#39;t",
+                    "chang",
+                    "class",
+                    "class=\"anchor\"></a>dehydration/rehydr",
+                    "class=\"anchor\"></a>featur",
+                    "class=\"anchor\"></a>flow",
+                    "class=\"anchor\"></a>plugg",
+                    "class=\"anchor\"></a>react",
+                    "class=\"anchor\"></a>singleton",
+                    "class=\"anchor\"></a>upd",
+                    "class=\"hash",
+                    "client",
+                    "client.</p",
+                    "code>dehydrate</cod",
+                    "code>rehydrate</cod",
+                    "come",
+                    "contain",
+                    "context.html\">fluxiblecontext</a",
+                    "contexts.</p",
+                    "deprec",
+                    "ensur",
+                    "flow",
+                    "flow.</p",
+                    "flux",
+                    "fluxibl",
+                    "follow",
+                    "free",
+                    "h1><a",
+                    "h2><a",
+                    "href=\"#dehydr",
+                    "href=\"#featur",
+                    "href=\"#flow",
+                    "href=\"#plugg",
+                    "href=\"#react",
+                    "href=\"#singleton",
+                    "href=\"#upd",
+                    "href=\"/api/components.html\">components</a",
+                    "href=\"/api/flux",
+                    "href=\"/api/plugins.html\">plugins</a",
+                    "href=\"/api/stores.html\">stores</a",
+                    "inform",
+                    "initi",
+                    "instanti",
+                    "integr",
+                    "interfac",
+                    "isol",
+                    "isomorph",
+                    "less",
+                    "link\">#</a></h1><h2><a",
+                    "link\">#</a></h2><p><a",
+                    "link\">#</a></h2><p>help",
+                    "link\">#</a></h2><p>upd",
+                    "link\">#</a></h2><p>w",
+                    "method",
+                    "name=\"dehydr",
+                    "name=\"featur",
+                    "name=\"flow",
+                    "name=\"plugg",
+                    "name=\"react",
+                    "name=\"singleton",
+                    "name=\"upd",
+                    "next",
+                    "out",
+                    "per",
+                    "pluggabl",
+                    "propag",
+                    "provid",
+                    "react",
+                    "react.</p",
+                    "regul",
+                    "rehydr",
+                    "render",
+                    "request",
+                    "requests.</p",
+                    "restrict",
+                    "server",
+                    "session",
+                    "state",
+                    "store",
+                    "unidirect",
+                    "util",
+                    "version"
+                ]
+            },
+            "length": 1
+        },
+        "tokenStore": {
+            "root": {
+                "0": {
+                    "docs": {
+                        "/docs/home.md": {
+                            "ref": "/docs/home.md",
+                            "tf": 0.015873015873015872
+                        }
+                    },
+                    ".": {
+                        "1": {
+                            "3": {
+                                "docs": {
+                                    "/docs/home.md": {
+                                        "ref": "/docs/home.md",
+                                        "tf": 0.007936507936507936
+                                    }
+                                },
+                                "&": {
+                                    "docs": {},
+                                    "#": {
+                                        "3": {
+                                            "9": {
+                                                "docs": {},
+                                                ";": {
+                                                    "docs": {
+                                                        "/docs/home.md": {
+                                                            "ref": "/docs/home.md",
+                                                            "tf": 0.007936507936507936
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "docs": {}
+                                        },
+                                        "docs": {}
+                                    }
+                                }
+                            },
+                            "docs": {}
+                        },
+                        "docs": {}
+                    }
+                },
+                "1": {
+                    "3": {
+                        "docs": {
+                            "/docs/home.md": {
+                                "ref": "/docs/home.md",
+                                "tf": 0.015873015873015872
+                            }
+                        }
+                    },
+                    "docs": {}
+                },
+                "docs": {},
+                "a": {
+                    "docs": {},
+                    "c": {
+                        "docs": {},
+                        "c": {
+                            "docs": {},
+                            "e": {
+                                "docs": {},
+                                "s": {
+                                    "docs": {},
+                                    "s": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.007936507936507936
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "d": {
+                        "docs": {},
+                        "d": {
+                            "docs": {
+                                "/docs/home.md": {
+                                    "ref": "/docs/home.md",
+                                    "tf": 0.015873015873015872
+                                }
+                            }
+                        }
+                    },
+                    "l": {
+                        "docs": {},
+                        "l": {
+                            "docs": {},
+                            "o": {
+                                "docs": {},
+                                "w": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.007936507936507936
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "p": {
+                        "docs": {},
+                        "p": {
+                            "docs": {
+                                "/docs/home.md": {
+                                    "ref": "/docs/home.md",
+                                    "tf": 0.007936507936507936
+                                }
+                            },
+                            "l": {
+                                "docs": {},
+                                "i": {
+                                    "docs": {},
+                                    "c": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 2.6666666666666665
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "b": {
+                    "docs": {},
+                    "e": {
+                        "docs": {},
+                        "t": {
+                            "docs": {},
+                            "w": {
+                                "docs": {},
+                                "e": {
+                                    "docs": {},
+                                    "e": {
+                                        "docs": {},
+                                        "n": {
+                                            "docs": {
+                                                "/docs/home.md": {
+                                                    "ref": "/docs/home.md",
+                                                    "tf": 0.007936507936507936
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "l": {
+                        "docs": {},
+                        "e": {
+                            "docs": {},
+                            "e": {
+                                "docs": {},
+                                "d": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.007936507936507936
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "o": {
+                        "docs": {},
+                        "i": {
+                            "docs": {},
+                            "l": {
+                                "docs": {},
+                                "e": {
+                                    "docs": {},
+                                    "r": {
+                                        "docs": {},
+                                        "p": {
+                                            "docs": {},
+                                            "l": {
+                                                "docs": {},
+                                                "a": {
+                                                    "docs": {},
+                                                    "t": {
+                                                        "docs": {},
+                                                        "e": {
+                                                            "docs": {},
+                                                            ".": {
+                                                                "docs": {},
+                                                                "<": {
+                                                                    "docs": {},
+                                                                    "/": {
+                                                                        "docs": {},
+                                                                        "p": {
+                                                                            "docs": {
+                                                                                "/docs/home.md": {
+                                                                                    "ref": "/docs/home.md",
+                                                                                    "tf": 0.007936507936507936
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "r": {
+                        "docs": {},
+                        "e": {
+                            "docs": {},
+                            "a": {
+                                "docs": {},
+                                "k": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.007936507936507936
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "c": {
+                    "docs": {},
+                    "a": {
+                        "docs": {},
+                        "n": {
+                            "docs": {},
+                            "&": {
+                                "docs": {},
+                                "#": {
+                                    "3": {
+                                        "9": {
+                                            "docs": {},
+                                            ";": {
+                                                "docs": {},
+                                                "t": {
+                                                    "docs": {
+                                                        "/docs/home.md": {
+                                                            "ref": "/docs/home.md",
+                                                            "tf": 0.007936507936507936
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "docs": {}
+                                    },
+                                    "docs": {}
+                                }
+                            }
+                        }
+                    },
+                    "h": {
+                        "docs": {},
+                        "a": {
+                            "docs": {},
+                            "n": {
+                                "docs": {},
+                                "g": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.007936507936507936
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "l": {
+                        "docs": {},
+                        "a": {
+                            "docs": {},
+                            "s": {
+                                "docs": {},
+                                "s": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.007936507936507936
+                                        }
+                                    },
+                                    "=": {
+                                        "docs": {},
+                                        "\"": {
+                                            "docs": {},
+                                            "a": {
+                                                "docs": {},
+                                                "n": {
+                                                    "docs": {},
+                                                    "c": {
+                                                        "docs": {},
+                                                        "h": {
+                                                            "docs": {},
+                                                            "o": {
+                                                                "docs": {},
+                                                                "r": {
+                                                                    "docs": {},
+                                                                    "\"": {
+                                                                        "docs": {},
+                                                                        ">": {
+                                                                            "docs": {},
+                                                                            "<": {
+                                                                                "docs": {},
+                                                                                "/": {
+                                                                                    "docs": {},
+                                                                                    "a": {
+                                                                                        "docs": {},
+                                                                                        ">": {
+                                                                                            "docs": {},
+                                                                                            "d": {
+                                                                                                "docs": {},
+                                                                                                "e": {
+                                                                                                    "docs": {},
+                                                                                                    "h": {
+                                                                                                        "docs": {},
+                                                                                                        "y": {
+                                                                                                            "docs": {},
+                                                                                                            "d": {
+                                                                                                                "docs": {},
+                                                                                                                "r": {
+                                                                                                                    "docs": {},
+                                                                                                                    "a": {
+                                                                                                                        "docs": {},
+                                                                                                                        "t": {
+                                                                                                                            "docs": {},
+                                                                                                                            "i": {
+                                                                                                                                "docs": {},
+                                                                                                                                "o": {
+                                                                                                                                    "docs": {},
+                                                                                                                                    "n": {
+                                                                                                                                        "docs": {},
+                                                                                                                                        "/": {
+                                                                                                                                            "docs": {},
+                                                                                                                                            "r": {
+                                                                                                                                                "docs": {},
+                                                                                                                                                "e": {
+                                                                                                                                                    "docs": {},
+                                                                                                                                                    "h": {
+                                                                                                                                                        "docs": {},
+                                                                                                                                                        "y": {
+                                                                                                                                                            "docs": {},
+                                                                                                                                                            "d": {
+                                                                                                                                                                "docs": {},
+                                                                                                                                                                "r": {
+                                                                                                                                                                    "docs": {
+                                                                                                                                                                        "/docs/home.md": {
+                                                                                                                                                                            "ref": "/docs/home.md",
+                                                                                                                                                                            "tf": 0.007936507936507936
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            "f": {
+                                                                                                "docs": {},
+                                                                                                "e": {
+                                                                                                    "docs": {},
+                                                                                                    "a": {
+                                                                                                        "docs": {},
+                                                                                                        "t": {
+                                                                                                            "docs": {},
+                                                                                                            "u": {
+                                                                                                                "docs": {},
+                                                                                                                "r": {
+                                                                                                                    "docs": {
+                                                                                                                        "/docs/home.md": {
+                                                                                                                            "ref": "/docs/home.md",
+                                                                                                                            "tf": 0.007936507936507936
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                },
+                                                                                                "l": {
+                                                                                                    "docs": {},
+                                                                                                    "o": {
+                                                                                                        "docs": {},
+                                                                                                        "w": {
+                                                                                                            "docs": {
+                                                                                                                "/docs/home.md": {
+                                                                                                                    "ref": "/docs/home.md",
+                                                                                                                    "tf": 0.007936507936507936
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            "p": {
+                                                                                                "docs": {},
+                                                                                                "l": {
+                                                                                                    "docs": {},
+                                                                                                    "u": {
+                                                                                                        "docs": {},
+                                                                                                        "g": {
+                                                                                                            "docs": {},
+                                                                                                            "g": {
+                                                                                                                "docs": {
+                                                                                                                    "/docs/home.md": {
+                                                                                                                        "ref": "/docs/home.md",
+                                                                                                                        "tf": 0.007936507936507936
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            "r": {
+                                                                                                "docs": {},
+                                                                                                "e": {
+                                                                                                    "docs": {},
+                                                                                                    "a": {
+                                                                                                        "docs": {},
+                                                                                                        "c": {
+                                                                                                            "docs": {},
+                                                                                                            "t": {
+                                                                                                                "docs": {
+                                                                                                                    "/docs/home.md": {
+                                                                                                                        "ref": "/docs/home.md",
+                                                                                                                        "tf": 0.007936507936507936
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            "s": {
+                                                                                                "docs": {},
+                                                                                                "i": {
+                                                                                                    "docs": {},
+                                                                                                    "n": {
+                                                                                                        "docs": {},
+                                                                                                        "g": {
+                                                                                                            "docs": {},
+                                                                                                            "l": {
+                                                                                                                "docs": {},
+                                                                                                                "e": {
+                                                                                                                    "docs": {},
+                                                                                                                    "t": {
+                                                                                                                        "docs": {},
+                                                                                                                        "o": {
+                                                                                                                            "docs": {},
+                                                                                                                            "n": {
+                                                                                                                                "docs": {
+                                                                                                                                    "/docs/home.md": {
+                                                                                                                                        "ref": "/docs/home.md",
+                                                                                                                                        "tf": 0.007936507936507936
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            "u": {
+                                                                                                "docs": {},
+                                                                                                "p": {
+                                                                                                    "docs": {},
+                                                                                                    "d": {
+                                                                                                        "docs": {
+                                                                                                            "/docs/home.md": {
+                                                                                                                "ref": "/docs/home.md",
+                                                                                                                "tf": 0.007936507936507936
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "h": {
+                                                "docs": {},
+                                                "a": {
+                                                    "docs": {},
+                                                    "s": {
+                                                        "docs": {},
+                                                        "h": {
+                                                            "docs": {
+                                                                "/docs/home.md": {
+                                                                    "ref": "/docs/home.md",
+                                                                    "tf": 0.05555555555555555
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "i": {
+                            "docs": {},
+                            "e": {
+                                "docs": {},
+                                "n": {
+                                    "docs": {},
+                                    "t": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.007936507936507936
+                                            }
+                                        },
+                                        ".": {
+                                            "docs": {},
+                                            "<": {
+                                                "docs": {},
+                                                "/": {
+                                                    "docs": {},
+                                                    "p": {
+                                                        "docs": {
+                                                            "/docs/home.md": {
+                                                                "ref": "/docs/home.md",
+                                                                "tf": 0.007936507936507936
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "o": {
+                        "docs": {},
+                        "d": {
+                            "docs": {},
+                            "e": {
+                                "docs": {},
+                                ">": {
+                                    "docs": {},
+                                    "d": {
+                                        "docs": {},
+                                        "e": {
+                                            "docs": {},
+                                            "h": {
+                                                "docs": {},
+                                                "y": {
+                                                    "docs": {},
+                                                    "d": {
+                                                        "docs": {},
+                                                        "r": {
+                                                            "docs": {},
+                                                            "a": {
+                                                                "docs": {},
+                                                                "t": {
+                                                                    "docs": {},
+                                                                    "e": {
+                                                                        "docs": {},
+                                                                        "<": {
+                                                                            "docs": {},
+                                                                            "/": {
+                                                                                "docs": {},
+                                                                                "c": {
+                                                                                    "docs": {},
+                                                                                    "o": {
+                                                                                        "docs": {},
+                                                                                        "d": {
+                                                                                            "docs": {
+                                                                                                "/docs/home.md": {
+                                                                                                    "ref": "/docs/home.md",
+                                                                                                    "tf": 0.007936507936507936
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "r": {
+                                        "docs": {},
+                                        "e": {
+                                            "docs": {},
+                                            "h": {
+                                                "docs": {},
+                                                "y": {
+                                                    "docs": {},
+                                                    "d": {
+                                                        "docs": {},
+                                                        "r": {
+                                                            "docs": {},
+                                                            "a": {
+                                                                "docs": {},
+                                                                "t": {
+                                                                    "docs": {},
+                                                                    "e": {
+                                                                        "docs": {},
+                                                                        "<": {
+                                                                            "docs": {},
+                                                                            "/": {
+                                                                                "docs": {},
+                                                                                "c": {
+                                                                                    "docs": {},
+                                                                                    "o": {
+                                                                                        "docs": {},
+                                                                                        "d": {
+                                                                                            "docs": {
+                                                                                                "/docs/home.md": {
+                                                                                                    "ref": "/docs/home.md",
+                                                                                                    "tf": 0.007936507936507936
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "m": {
+                            "docs": {},
+                            "e": {
+                                "docs": {
+                                    "/docs/home.md": {
+                                        "ref": "/docs/home.md",
+                                        "tf": 0.007936507936507936
+                                    }
+                                }
+                            }
+                        },
+                        "n": {
+                            "docs": {},
+                            "t": {
+                                "docs": {},
+                                "a": {
+                                    "docs": {},
+                                    "i": {
+                                        "docs": {},
+                                        "n": {
+                                            "docs": {
+                                                "/docs/home.md": {
+                                                    "ref": "/docs/home.md",
+                                                    "tf": 2.6666666666666665
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "e": {
+                                    "docs": {},
+                                    "x": {
+                                        "docs": {},
+                                        "t": {
+                                            "docs": {},
+                                            ".": {
+                                                "docs": {},
+                                                "h": {
+                                                    "docs": {},
+                                                    "t": {
+                                                        "docs": {},
+                                                        "m": {
+                                                            "docs": {},
+                                                            "l": {
+                                                                "docs": {},
+                                                                "\"": {
+                                                                    "docs": {},
+                                                                    ">": {
+                                                                        "docs": {},
+                                                                        "f": {
+                                                                            "docs": {},
+                                                                            "l": {
+                                                                                "docs": {},
+                                                                                "u": {
+                                                                                    "docs": {},
+                                                                                    "x": {
+                                                                                        "docs": {},
+                                                                                        "i": {
+                                                                                            "docs": {},
+                                                                                            "b": {
+                                                                                                "docs": {},
+                                                                                                "l": {
+                                                                                                    "docs": {},
+                                                                                                    "e": {
+                                                                                                        "docs": {},
+                                                                                                        "c": {
+                                                                                                            "docs": {},
+                                                                                                            "o": {
+                                                                                                                "docs": {},
+                                                                                                                "n": {
+                                                                                                                    "docs": {},
+                                                                                                                    "t": {
+                                                                                                                        "docs": {},
+                                                                                                                        "e": {
+                                                                                                                            "docs": {},
+                                                                                                                            "x": {
+                                                                                                                                "docs": {},
+                                                                                                                                "t": {
+                                                                                                                                    "docs": {},
+                                                                                                                                    "<": {
+                                                                                                                                        "docs": {},
+                                                                                                                                        "/": {
+                                                                                                                                            "docs": {},
+                                                                                                                                            "a": {
+                                                                                                                                                "docs": {
+                                                                                                                                                    "/docs/home.md": {
+                                                                                                                                                        "ref": "/docs/home.md",
+                                                                                                                                                        "tf": 0.007936507936507936
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "s": {
+                                                "docs": {},
+                                                ".": {
+                                                    "docs": {},
+                                                    "<": {
+                                                        "docs": {},
+                                                        "/": {
+                                                            "docs": {},
+                                                            "p": {
+                                                                "docs": {
+                                                                    "/docs/home.md": {
+                                                                        "ref": "/docs/home.md",
+                                                                        "tf": 0.007936507936507936
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "d": {
+                    "docs": {},
+                    "e": {
+                        "docs": {},
+                        "p": {
+                            "docs": {},
+                            "r": {
+                                "docs": {},
+                                "e": {
+                                    "docs": {},
+                                    "c": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.007936507936507936
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "e": {
+                    "docs": {},
+                    "n": {
+                        "docs": {},
+                        "s": {
+                            "docs": {},
+                            "u": {
+                                "docs": {},
+                                "r": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.007936507936507936
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "f": {
+                    "docs": {},
+                    "l": {
+                        "docs": {},
+                        "o": {
+                            "docs": {},
+                            "w": {
+                                "docs": {
+                                    "/docs/home.md": {
+                                        "ref": "/docs/home.md",
+                                        "tf": 0.007936507936507936
+                                    }
+                                },
+                                ".": {
+                                    "docs": {},
+                                    "<": {
+                                        "docs": {},
+                                        "/": {
+                                            "docs": {},
+                                            "p": {
+                                                "docs": {
+                                                    "/docs/home.md": {
+                                                        "ref": "/docs/home.md",
+                                                        "tf": 0.007936507936507936
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "u": {
+                            "docs": {},
+                            "x": {
+                                "docs": {
+                                    "/docs/home.md": {
+                                        "ref": "/docs/home.md",
+                                        "tf": 2.6825396825396823
+                                    }
+                                },
+                                "i": {
+                                    "docs": {},
+                                    "b": {
+                                        "docs": {},
+                                        "l": {
+                                            "docs": {
+                                                "/docs/home.md": {
+                                                    "ref": "/docs/home.md",
+                                                    "tf": 1.6746031746031744
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "o": {
+                        "docs": {},
+                        "l": {
+                            "docs": {},
+                            "l": {
+                                "docs": {},
+                                "o": {
+                                    "docs": {},
+                                    "w": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.007936507936507936
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "r": {
+                        "docs": {},
+                        "e": {
+                            "docs": {},
+                            "e": {
+                                "docs": {
+                                    "/docs/home.md": {
+                                        "ref": "/docs/home.md",
+                                        "tf": 0.023809523809523808
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "h": {
+                    "1": {
+                        "docs": {},
+                        ">": {
+                            "docs": {},
+                            "<": {
+                                "docs": {},
+                                "a": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.007936507936507936
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "2": {
+                        "docs": {},
+                        ">": {
+                            "docs": {},
+                            "<": {
+                                "docs": {},
+                                "a": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.03968253968253968
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "docs": {},
+                    "r": {
+                        "docs": {},
+                        "e": {
+                            "docs": {},
+                            "f": {
+                                "docs": {},
+                                "=": {
+                                    "docs": {},
+                                    "\"": {
+                                        "docs": {},
+                                        "#": {
+                                            "docs": {},
+                                            "d": {
+                                                "docs": {},
+                                                "e": {
+                                                    "docs": {},
+                                                    "h": {
+                                                        "docs": {},
+                                                        "y": {
+                                                            "docs": {},
+                                                            "d": {
+                                                                "docs": {},
+                                                                "r": {
+                                                                    "docs": {
+                                                                        "/docs/home.md": {
+                                                                            "ref": "/docs/home.md",
+                                                                            "tf": 0.007936507936507936
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "f": {
+                                                "docs": {},
+                                                "e": {
+                                                    "docs": {},
+                                                    "a": {
+                                                        "docs": {},
+                                                        "t": {
+                                                            "docs": {},
+                                                            "u": {
+                                                                "docs": {},
+                                                                "r": {
+                                                                    "docs": {
+                                                                        "/docs/home.md": {
+                                                                            "ref": "/docs/home.md",
+                                                                            "tf": 0.007936507936507936
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "l": {
+                                                    "docs": {},
+                                                    "o": {
+                                                        "docs": {},
+                                                        "w": {
+                                                            "docs": {
+                                                                "/docs/home.md": {
+                                                                    "ref": "/docs/home.md",
+                                                                    "tf": 0.007936507936507936
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "p": {
+                                                "docs": {},
+                                                "l": {
+                                                    "docs": {},
+                                                    "u": {
+                                                        "docs": {},
+                                                        "g": {
+                                                            "docs": {},
+                                                            "g": {
+                                                                "docs": {
+                                                                    "/docs/home.md": {
+                                                                        "ref": "/docs/home.md",
+                                                                        "tf": 0.007936507936507936
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "r": {
+                                                "docs": {},
+                                                "e": {
+                                                    "docs": {},
+                                                    "a": {
+                                                        "docs": {},
+                                                        "c": {
+                                                            "docs": {},
+                                                            "t": {
+                                                                "docs": {
+                                                                    "/docs/home.md": {
+                                                                        "ref": "/docs/home.md",
+                                                                        "tf": 0.007936507936507936
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "s": {
+                                                "docs": {},
+                                                "i": {
+                                                    "docs": {},
+                                                    "n": {
+                                                        "docs": {},
+                                                        "g": {
+                                                            "docs": {},
+                                                            "l": {
+                                                                "docs": {},
+                                                                "e": {
+                                                                    "docs": {},
+                                                                    "t": {
+                                                                        "docs": {},
+                                                                        "o": {
+                                                                            "docs": {},
+                                                                            "n": {
+                                                                                "docs": {
+                                                                                    "/docs/home.md": {
+                                                                                        "ref": "/docs/home.md",
+                                                                                        "tf": 0.007936507936507936
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "u": {
+                                                "docs": {},
+                                                "p": {
+                                                    "docs": {},
+                                                    "d": {
+                                                        "docs": {
+                                                            "/docs/home.md": {
+                                                                "ref": "/docs/home.md",
+                                                                "tf": 0.007936507936507936
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "/": {
+                                            "docs": {},
+                                            "a": {
+                                                "docs": {},
+                                                "p": {
+                                                    "docs": {},
+                                                    "i": {
+                                                        "docs": {},
+                                                        "/": {
+                                                            "docs": {},
+                                                            "c": {
+                                                                "docs": {},
+                                                                "o": {
+                                                                    "docs": {},
+                                                                    "m": {
+                                                                        "docs": {},
+                                                                        "p": {
+                                                                            "docs": {},
+                                                                            "o": {
+                                                                                "docs": {},
+                                                                                "n": {
+                                                                                    "docs": {},
+                                                                                    "e": {
+                                                                                        "docs": {},
+                                                                                        "n": {
+                                                                                            "docs": {},
+                                                                                            "t": {
+                                                                                                "docs": {},
+                                                                                                "s": {
+                                                                                                    "docs": {},
+                                                                                                    ".": {
+                                                                                                        "docs": {},
+                                                                                                        "h": {
+                                                                                                            "docs": {},
+                                                                                                            "t": {
+                                                                                                                "docs": {},
+                                                                                                                "m": {
+                                                                                                                    "docs": {},
+                                                                                                                    "l": {
+                                                                                                                        "docs": {},
+                                                                                                                        "\"": {
+                                                                                                                            "docs": {},
+                                                                                                                            ">": {
+                                                                                                                                "docs": {},
+                                                                                                                                "c": {
+                                                                                                                                    "docs": {},
+                                                                                                                                    "o": {
+                                                                                                                                        "docs": {},
+                                                                                                                                        "m": {
+                                                                                                                                            "docs": {},
+                                                                                                                                            "p": {
+                                                                                                                                                "docs": {},
+                                                                                                                                                "o": {
+                                                                                                                                                    "docs": {},
+                                                                                                                                                    "n": {
+                                                                                                                                                        "docs": {},
+                                                                                                                                                        "e": {
+                                                                                                                                                            "docs": {},
+                                                                                                                                                            "n": {
+                                                                                                                                                                "docs": {},
+                                                                                                                                                                "t": {
+                                                                                                                                                                    "docs": {},
+                                                                                                                                                                    "s": {
+                                                                                                                                                                        "docs": {},
+                                                                                                                                                                        "<": {
+                                                                                                                                                                            "docs": {},
+                                                                                                                                                                            "/": {
+                                                                                                                                                                                "docs": {},
+                                                                                                                                                                                "a": {
+                                                                                                                                                                                    "docs": {
+                                                                                                                                                                                        "/docs/home.md": {
+                                                                                                                                                                                            "ref": "/docs/home.md",
+                                                                                                                                                                                            "tf": 0.007936507936507936
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            "f": {
+                                                                "docs": {},
+                                                                "l": {
+                                                                    "docs": {},
+                                                                    "u": {
+                                                                        "docs": {},
+                                                                        "x": {
+                                                                            "docs": {
+                                                                                "/docs/home.md": {
+                                                                                    "ref": "/docs/home.md",
+                                                                                    "tf": 0.007936507936507936
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            "p": {
+                                                                "docs": {},
+                                                                "l": {
+                                                                    "docs": {},
+                                                                    "u": {
+                                                                        "docs": {},
+                                                                        "g": {
+                                                                            "docs": {},
+                                                                            "i": {
+                                                                                "docs": {},
+                                                                                "n": {
+                                                                                    "docs": {},
+                                                                                    "s": {
+                                                                                        "docs": {},
+                                                                                        ".": {
+                                                                                            "docs": {},
+                                                                                            "h": {
+                                                                                                "docs": {},
+                                                                                                "t": {
+                                                                                                    "docs": {},
+                                                                                                    "m": {
+                                                                                                        "docs": {},
+                                                                                                        "l": {
+                                                                                                            "docs": {},
+                                                                                                            "\"": {
+                                                                                                                "docs": {},
+                                                                                                                ">": {
+                                                                                                                    "docs": {},
+                                                                                                                    "p": {
+                                                                                                                        "docs": {},
+                                                                                                                        "l": {
+                                                                                                                            "docs": {},
+                                                                                                                            "u": {
+                                                                                                                                "docs": {},
+                                                                                                                                "g": {
+                                                                                                                                    "docs": {},
+                                                                                                                                    "i": {
+                                                                                                                                        "docs": {},
+                                                                                                                                        "n": {
+                                                                                                                                            "docs": {},
+                                                                                                                                            "s": {
+                                                                                                                                                "docs": {},
+                                                                                                                                                "<": {
+                                                                                                                                                    "docs": {},
+                                                                                                                                                    "/": {
+                                                                                                                                                        "docs": {},
+                                                                                                                                                        "a": {
+                                                                                                                                                            "docs": {
+                                                                                                                                                                "/docs/home.md": {
+                                                                                                                                                                    "ref": "/docs/home.md",
+                                                                                                                                                                    "tf": 0.007936507936507936
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            "s": {
+                                                                "docs": {},
+                                                                "t": {
+                                                                    "docs": {},
+                                                                    "o": {
+                                                                        "docs": {},
+                                                                        "r": {
+                                                                            "docs": {},
+                                                                            "e": {
+                                                                                "docs": {},
+                                                                                "s": {
+                                                                                    "docs": {},
+                                                                                    ".": {
+                                                                                        "docs": {},
+                                                                                        "h": {
+                                                                                            "docs": {},
+                                                                                            "t": {
+                                                                                                "docs": {},
+                                                                                                "m": {
+                                                                                                    "docs": {},
+                                                                                                    "l": {
+                                                                                                        "docs": {},
+                                                                                                        "\"": {
+                                                                                                            "docs": {},
+                                                                                                            ">": {
+                                                                                                                "docs": {},
+                                                                                                                "s": {
+                                                                                                                    "docs": {},
+                                                                                                                    "t": {
+                                                                                                                        "docs": {},
+                                                                                                                        "o": {
+                                                                                                                            "docs": {},
+                                                                                                                            "r": {
+                                                                                                                                "docs": {},
+                                                                                                                                "e": {
+                                                                                                                                    "docs": {},
+                                                                                                                                    "s": {
+                                                                                                                                        "docs": {},
+                                                                                                                                        "<": {
+                                                                                                                                            "docs": {},
+                                                                                                                                            "/": {
+                                                                                                                                                "docs": {},
+                                                                                                                                                "a": {
+                                                                                                                                                    "docs": {
+                                                                                                                                                        "/docs/home.md": {
+                                                                                                                                                            "ref": "/docs/home.md",
+                                                                                                                                                            "tf": 0.015873015873015872
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "i": {
+                    "docs": {},
+                    "n": {
+                        "docs": {},
+                        "f": {
+                            "docs": {},
+                            "o": {
+                                "docs": {},
+                                "r": {
+                                    "docs": {},
+                                    "m": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.007936507936507936
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "i": {
+                            "docs": {},
+                            "t": {
+                                "docs": {},
+                                "i": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.007936507936507936
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "s": {
+                            "docs": {},
+                            "t": {
+                                "docs": {},
+                                "a": {
+                                    "docs": {},
+                                    "n": {
+                                        "docs": {},
+                                        "t": {
+                                            "docs": {},
+                                            "i": {
+                                                "docs": {
+                                                    "/docs/home.md": {
+                                                        "ref": "/docs/home.md",
+                                                        "tf": 0.007936507936507936
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "t": {
+                            "docs": {},
+                            "e": {
+                                "docs": {},
+                                "g": {
+                                    "docs": {},
+                                    "r": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.031746031746031744
+                                            }
+                                        }
+                                    }
+                                },
+                                "r": {
+                                    "docs": {},
+                                    "f": {
+                                        "docs": {},
+                                        "a": {
+                                            "docs": {},
+                                            "c": {
+                                                "docs": {
+                                                    "/docs/home.md": {
+                                                        "ref": "/docs/home.md",
+                                                        "tf": 0.007936507936507936
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "s": {
+                        "docs": {},
+                        "o": {
+                            "docs": {},
+                            "l": {
+                                "docs": {
+                                    "/docs/home.md": {
+                                        "ref": "/docs/home.md",
+                                        "tf": 0.007936507936507936
+                                    }
+                                }
+                            },
+                            "m": {
+                                "docs": {},
+                                "o": {
+                                    "docs": {},
+                                    "r": {
+                                        "docs": {},
+                                        "p": {
+                                            "docs": {},
+                                            "h": {
+                                                "docs": {
+                                                    "/docs/home.md": {
+                                                        "ref": "/docs/home.md",
+                                                        "tf": 2.6666666666666665
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "l": {
+                    "docs": {},
+                    "e": {
+                        "docs": {},
+                        "s": {
+                            "docs": {},
+                            "s": {
+                                "docs": {
+                                    "/docs/home.md": {
+                                        "ref": "/docs/home.md",
+                                        "tf": 0.007936507936507936
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "i": {
+                        "docs": {},
+                        "n": {
+                            "docs": {},
+                            "k": {
+                                "docs": {},
+                                "\"": {
+                                    "docs": {},
+                                    ">": {
+                                        "docs": {},
+                                        "#": {
+                                            "docs": {},
+                                            "<": {
+                                                "docs": {},
+                                                "/": {
+                                                    "docs": {},
+                                                    "a": {
+                                                        "docs": {},
+                                                        ">": {
+                                                            "docs": {},
+                                                            "<": {
+                                                                "docs": {},
+                                                                "/": {
+                                                                    "docs": {},
+                                                                    "h": {
+                                                                        "1": {
+                                                                            "docs": {},
+                                                                            ">": {
+                                                                                "docs": {},
+                                                                                "<": {
+                                                                                    "docs": {},
+                                                                                    "h": {
+                                                                                        "2": {
+                                                                                            "docs": {},
+                                                                                            ">": {
+                                                                                                "docs": {},
+                                                                                                "<": {
+                                                                                                    "docs": {},
+                                                                                                    "a": {
+                                                                                                        "docs": {
+                                                                                                            "/docs/home.md": {
+                                                                                                                "ref": "/docs/home.md",
+                                                                                                                "tf": 0.007936507936507936
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        },
+                                                                                        "docs": {}
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "2": {
+                                                                            "docs": {},
+                                                                            ">": {
+                                                                                "docs": {},
+                                                                                "<": {
+                                                                                    "docs": {},
+                                                                                    "p": {
+                                                                                        "docs": {},
+                                                                                        ">": {
+                                                                                            "docs": {},
+                                                                                            "<": {
+                                                                                                "docs": {},
+                                                                                                "a": {
+                                                                                                    "docs": {
+                                                                                                        "/docs/home.md": {
+                                                                                                            "ref": "/docs/home.md",
+                                                                                                            "tf": 0.023809523809523808
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            "h": {
+                                                                                                "docs": {},
+                                                                                                "e": {
+                                                                                                    "docs": {},
+                                                                                                    "l": {
+                                                                                                        "docs": {},
+                                                                                                        "p": {
+                                                                                                            "docs": {
+                                                                                                                "/docs/home.md": {
+                                                                                                                    "ref": "/docs/home.md",
+                                                                                                                    "tf": 0.007936507936507936
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            "u": {
+                                                                                                "docs": {},
+                                                                                                "p": {
+                                                                                                    "docs": {},
+                                                                                                    "d": {
+                                                                                                        "docs": {
+                                                                                                            "/docs/home.md": {
+                                                                                                                "ref": "/docs/home.md",
+                                                                                                                "tf": 0.007936507936507936
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            "w": {
+                                                                                                "docs": {
+                                                                                                    "/docs/home.md": {
+                                                                                                        "ref": "/docs/home.md",
+                                                                                                        "tf": 0.007936507936507936
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "docs": {}
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "m": {
+                    "docs": {},
+                    "e": {
+                        "docs": {},
+                        "t": {
+                            "docs": {},
+                            "h": {
+                                "docs": {},
+                                "o": {
+                                    "docs": {},
+                                    "d": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.015873015873015872
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "n": {
+                    "docs": {},
+                    "a": {
+                        "docs": {},
+                        "m": {
+                            "docs": {},
+                            "e": {
+                                "docs": {},
+                                "=": {
+                                    "docs": {},
+                                    "\"": {
+                                        "docs": {},
+                                        "d": {
+                                            "docs": {},
+                                            "e": {
+                                                "docs": {},
+                                                "h": {
+                                                    "docs": {},
+                                                    "y": {
+                                                        "docs": {},
+                                                        "d": {
+                                                            "docs": {},
+                                                            "r": {
+                                                                "docs": {
+                                                                    "/docs/home.md": {
+                                                                        "ref": "/docs/home.md",
+                                                                        "tf": 0.007936507936507936
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f": {
+                                            "docs": {},
+                                            "e": {
+                                                "docs": {},
+                                                "a": {
+                                                    "docs": {},
+                                                    "t": {
+                                                        "docs": {},
+                                                        "u": {
+                                                            "docs": {},
+                                                            "r": {
+                                                                "docs": {
+                                                                    "/docs/home.md": {
+                                                                        "ref": "/docs/home.md",
+                                                                        "tf": 0.007936507936507936
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "l": {
+                                                "docs": {},
+                                                "o": {
+                                                    "docs": {},
+                                                    "w": {
+                                                        "docs": {
+                                                            "/docs/home.md": {
+                                                                "ref": "/docs/home.md",
+                                                                "tf": 0.007936507936507936
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "p": {
+                                            "docs": {},
+                                            "l": {
+                                                "docs": {},
+                                                "u": {
+                                                    "docs": {},
+                                                    "g": {
+                                                        "docs": {},
+                                                        "g": {
+                                                            "docs": {
+                                                                "/docs/home.md": {
+                                                                    "ref": "/docs/home.md",
+                                                                    "tf": 0.007936507936507936
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "r": {
+                                            "docs": {},
+                                            "e": {
+                                                "docs": {},
+                                                "a": {
+                                                    "docs": {},
+                                                    "c": {
+                                                        "docs": {},
+                                                        "t": {
+                                                            "docs": {
+                                                                "/docs/home.md": {
+                                                                    "ref": "/docs/home.md",
+                                                                    "tf": 0.007936507936507936
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "s": {
+                                            "docs": {},
+                                            "i": {
+                                                "docs": {},
+                                                "n": {
+                                                    "docs": {},
+                                                    "g": {
+                                                        "docs": {},
+                                                        "l": {
+                                                            "docs": {},
+                                                            "e": {
+                                                                "docs": {},
+                                                                "t": {
+                                                                    "docs": {},
+                                                                    "o": {
+                                                                        "docs": {},
+                                                                        "n": {
+                                                                            "docs": {
+                                                                                "/docs/home.md": {
+                                                                                    "ref": "/docs/home.md",
+                                                                                    "tf": 0.007936507936507936
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "u": {
+                                            "docs": {},
+                                            "p": {
+                                                "docs": {},
+                                                "d": {
+                                                    "docs": {
+                                                        "/docs/home.md": {
+                                                            "ref": "/docs/home.md",
+                                                            "tf": 0.007936507936507936
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "e": {
+                        "docs": {},
+                        "x": {
+                            "docs": {},
+                            "t": {
+                                "docs": {
+                                    "/docs/home.md": {
+                                        "ref": "/docs/home.md",
+                                        "tf": 0.007936507936507936
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "o": {
+                    "docs": {},
+                    "u": {
+                        "docs": {},
+                        "t": {
+                            "docs": {
+                                "/docs/home.md": {
+                                    "ref": "/docs/home.md",
+                                    "tf": 0.007936507936507936
+                                }
+                            }
+                        }
+                    }
+                },
+                "p": {
+                    "docs": {},
+                    "e": {
+                        "docs": {},
+                        "r": {
+                            "docs": {
+                                "/docs/home.md": {
+                                    "ref": "/docs/home.md",
+                                    "tf": 0.007936507936507936
+                                }
+                            }
+                        }
+                    },
+                    "l": {
+                        "docs": {},
+                        "u": {
+                            "docs": {},
+                            "g": {
+                                "docs": {},
+                                "g": {
+                                    "docs": {},
+                                    "a": {
+                                        "docs": {},
+                                        "b": {
+                                            "docs": {},
+                                            "l": {
+                                                "docs": {
+                                                    "/docs/home.md": {
+                                                        "ref": "/docs/home.md",
+                                                        "tf": 2.6666666666666665
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "r": {
+                        "docs": {},
+                        "o": {
+                            "docs": {},
+                            "p": {
+                                "docs": {},
+                                "a": {
+                                    "docs": {},
+                                    "g": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.007936507936507936
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "v": {
+                                "docs": {},
+                                "i": {
+                                    "docs": {},
+                                    "d": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.007936507936507936
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "r": {
+                    "docs": {},
+                    "e": {
+                        "docs": {},
+                        "a": {
+                            "docs": {},
+                            "c": {
+                                "docs": {},
+                                "t": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.03968253968253968
+                                        }
+                                    },
+                                    ".": {
+                                        "docs": {},
+                                        "<": {
+                                            "docs": {},
+                                            "/": {
+                                                "docs": {},
+                                                "p": {
+                                                    "docs": {
+                                                        "/docs/home.md": {
+                                                            "ref": "/docs/home.md",
+                                                            "tf": 0.007936507936507936
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "g": {
+                            "docs": {},
+                            "u": {
+                                "docs": {},
+                                "l": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.023809523809523808
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "h": {
+                            "docs": {},
+                            "y": {
+                                "docs": {},
+                                "d": {
+                                    "docs": {},
+                                    "r": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.015873015873015872
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "n": {
+                            "docs": {},
+                            "d": {
+                                "docs": {},
+                                "e": {
+                                    "docs": {},
+                                    "r": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.023809523809523808
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "q": {
+                            "docs": {},
+                            "u": {
+                                "docs": {},
+                                "e": {
+                                    "docs": {},
+                                    "s": {
+                                        "docs": {},
+                                        "t": {
+                                            "docs": {
+                                                "/docs/home.md": {
+                                                    "ref": "/docs/home.md",
+                                                    "tf": 0.007936507936507936
+                                                }
+                                            },
+                                            "s": {
+                                                "docs": {},
+                                                ".": {
+                                                    "docs": {},
+                                                    "<": {
+                                                        "docs": {},
+                                                        "/": {
+                                                            "docs": {},
+                                                            "p": {
+                                                                "docs": {
+                                                                    "/docs/home.md": {
+                                                                        "ref": "/docs/home.md",
+                                                                        "tf": 0.007936507936507936
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "s": {
+                            "docs": {},
+                            "t": {
+                                "docs": {},
+                                "r": {
+                                    "docs": {},
+                                    "i": {
+                                        "docs": {},
+                                        "c": {
+                                            "docs": {},
+                                            "t": {
+                                                "docs": {
+                                                    "/docs/home.md": {
+                                                        "ref": "/docs/home.md",
+                                                        "tf": 0.007936507936507936
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "s": {
+                    "docs": {},
+                    "e": {
+                        "docs": {},
+                        "r": {
+                            "docs": {},
+                            "v": {
+                                "docs": {},
+                                "e": {
+                                    "docs": {},
+                                    "r": {
+                                        "docs": {
+                                            "/docs/home.md": {
+                                                "ref": "/docs/home.md",
+                                                "tf": 0.031746031746031744
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "s": {
+                            "docs": {},
+                            "s": {
+                                "docs": {},
+                                "i": {
+                                    "docs": {},
+                                    "o": {
+                                        "docs": {},
+                                        "n": {
+                                            "docs": {
+                                                "/docs/home.md": {
+                                                    "ref": "/docs/home.md",
+                                                    "tf": 0.007936507936507936
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "t": {
+                        "docs": {},
+                        "a": {
+                            "docs": {},
+                            "t": {
+                                "docs": {},
+                                "e": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.007936507936507936
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "o": {
+                            "docs": {},
+                            "r": {
+                                "docs": {},
+                                "e": {
+                                    "docs": {
+                                        "/docs/home.md": {
+                                            "ref": "/docs/home.md",
+                                            "tf": 0.007936507936507936
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "u": {
+                    "docs": {},
+                    "n": {
+                        "docs": {},
+                        "i": {
+                            "docs": {},
+                            "d": {
+                                "docs": {},
+                                "i": {
+                                    "docs": {},
+                                    "r": {
+                                        "docs": {},
+                                        "e": {
+                                            "docs": {},
+                                            "c": {
+                                                "docs": {},
+                                                "t": {
+                                                    "docs": {
+                                                        "/docs/home.md": {
+                                                            "ref": "/docs/home.md",
+                                                            "tf": 0.007936507936507936
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "t": {
+                        "docs": {},
+                        "i": {
+                            "docs": {},
+                            "l": {
+                                "docs": {
+                                    "/docs/home.md": {
+                                        "ref": "/docs/home.md",
+                                        "tf": 0.007936507936507936
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "v": {
+                    "docs": {},
+                    "e": {
+                        "docs": {},
+                        "r": {
+                            "docs": {},
+                            "s": {
+                                "docs": {},
+                                "i": {
+                                    "docs": {},
+                                    "o": {
+                                        "docs": {},
+                                        "n": {
+                                            "docs": {
+                                                "/docs/home.md": {
+                                                    "ref": "/docs/home.md",
+                                                    "tf": 0.007936507936507936
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "length": 95
+        },
+        "corpusTokens": [
+            "0",
+            "0.13",
+            "0.13&#39;",
+            "13",
+            "access",
+            "add",
+            "allow",
+            "app",
+            "applic",
+            "between",
+            "bleed",
+            "boilerplate.</p",
+            "break",
+            "can&#39;t",
+            "chang",
+            "class",
+            "class=\"anchor\"></a>dehydration/rehydr",
+            "class=\"anchor\"></a>featur",
+            "class=\"anchor\"></a>flow",
+            "class=\"anchor\"></a>plugg",
+            "class=\"anchor\"></a>react",
+            "class=\"anchor\"></a>singleton",
+            "class=\"anchor\"></a>upd",
+            "class=\"hash",
+            "client",
+            "client.</p",
+            "code>dehydrate</cod",
+            "code>rehydrate</cod",
+            "come",
+            "contain",
+            "context.html\">fluxiblecontext</a",
+            "contexts.</p",
+            "deprec",
+            "ensur",
+            "flow",
+            "flow.</p",
+            "flux",
+            "fluxibl",
+            "follow",
+            "free",
+            "h1><a",
+            "h2><a",
+            "href=\"#dehydr",
+            "href=\"#featur",
+            "href=\"#flow",
+            "href=\"#plugg",
+            "href=\"#react",
+            "href=\"#singleton",
+            "href=\"#upd",
+            "href=\"/api/components.html\">components</a",
+            "href=\"/api/flux",
+            "href=\"/api/plugins.html\">plugins</a",
+            "href=\"/api/stores.html\">stores</a",
+            "inform",
+            "initi",
+            "instanti",
+            "integr",
+            "interfac",
+            "isol",
+            "isomorph",
+            "less",
+            "link\">#</a></h1><h2><a",
+            "link\">#</a></h2><p><a",
+            "link\">#</a></h2><p>help",
+            "link\">#</a></h2><p>upd",
+            "link\">#</a></h2><p>w",
+            "method",
+            "name=\"dehydr",
+            "name=\"featur",
+            "name=\"flow",
+            "name=\"plugg",
+            "name=\"react",
+            "name=\"singleton",
+            "name=\"upd",
+            "next",
+            "out",
+            "per",
+            "pluggabl",
+            "propag",
+            "provid",
+            "react",
+            "react.</p",
+            "regul",
+            "rehydr",
+            "render",
+            "request",
+            "requests.</p",
+            "restrict",
+            "server",
+            "session",
+            "state",
+            "store",
+            "unidirect",
+            "util",
+            "version"
+        ],
+        "pipeline": [
+            "trimmer",
+            "stopWordFilter",
+            "stemmer"
+        ]
+    }
+}

--- a/tests/spec/default.spec.js
+++ b/tests/spec/default.spec.js
@@ -19,65 +19,38 @@ describe('fluxible', function () {
     });
 
     it('follows get started link', function () {
-        browser.get(browser.baseUrl).then(function () {
-            expect(browser.getTitle()).to.eventually.match(/Fluxible/);
+        browser.get(browser.baseUrl);
+        expect(browser.getTitle()).to.eventually.match(/Fluxible/);
 
-            var splashLinks = browser.$$('#splash a');
-            var link = splashLinks.get(0);
+        $('#splash a').click();
 
-            link.click().then(function () {
-                var h1 = browser.$('#main h1');
-                var isPresent = EC.presenceOf(h1);
-                browser.wait(isPresent, 500);
+        var h1 = $('#main h1');
+        browser.wait(EC.presenceOf(h1), 500);
 
-                expect(h1.getText()).to.eventually.match(/Quick Start/);
-
-                expect(browser.getCurrentUrl()).to.eventually.match(/quick-start.html/);
-                expect(browser.getTitle()).to.eventually.match(/Quick Start/);
-            });
-        });
+        expect(h1.getText()).to.eventually.match(/Quick Start/);
+        expect(browser.getCurrentUrl()).to.eventually.match(/quick-start.html/);
+        expect(browser.getTitle()).to.eventually.match(/Quick Start/);
     });
 
     it('follows doc links', function () {
-        browser.get(browser.baseUrl + 'quick-start.html').then(function () {
-            expect(browser.getTitle()).to.eventually.match(/Quick Start/);
+        // load quick start page
+        browser.get(browser.baseUrl + 'quick-start.html');
+        expect(browser.getTitle()).to.eventually.match(/Quick Start/);
 
-            var menuLink = browser.$('#aside a.Actions');
-            var h1;
+        // navigate to Actions page
+        $('#aside a.Actions').click();
 
-            menuLink.click().then(function () {
-                var h1 = browser.$('#main h1');
-                var isPresent = EC.presenceOf(h1);
-                browser.wait(isPresent, 500);
+        var h1 = $('#main h1');
 
-                expect(h1.getText()).to.eventually.match(/Actions/);
-                expect(browser.getCurrentUrl()).to.eventually.match(/api\/actions.html/);
-                expect(browser.getTitle()).to.eventually.match(/Actions/);
+        // without this protractor tests the old dom node
+        // but react renders it away and causes stale element error
+        browser.wait(EC.stalenessOf(h1), 500);
 
-                menuLink = browser.$('#aside a.Components');
-            }).then(function () {
-                menuLink.click().then(function () {
-                    var h1 = browser.$('#main h1');
-                    var isPresent = EC.presenceOf(h1);
-                    browser.wait(isPresent, 500);
+        // this ensures the node is available
+        browser.wait(EC.presenceOf(h1), 500);
 
-                    expect(h1.getText()).to.eventually.match(/Components/);
-                    expect(browser.getCurrentUrl()).to.eventually.match(/api\/components.html/);
-                    expect(browser.getTitle()).to.eventually.match(/Components/);
-
-                    menuLink = browser.$$('#aside a.Routing');
-                });
-            }).then(function () {
-                menuLink.click().then(function () {
-                    var h1 = browser.$('#main h1');
-                    var isPresent = EC.presenceOf(h1);
-                    browser.wait(isPresent, 500);
-
-                    expect(h1.getText()).to.eventually.match(/Routing/);
-                    expect(browser.getCurrentUrl()).to.eventually.match(/tutorials\/routing.html/);
-                    expect(browser.getTitle()).to.eventually.match(/Routing/);
-                });
-            });
-        });
+        expect(h1.getText()).to.eventually.match(/Actions/);
+        expect(browser.getCurrentUrl()).to.eventually.match(/api\/actions.html/);
+        expect(browser.getTitle()).to.eventually.match(/Actions/);
     });
 });

--- a/tests/spec/search.spec.js
+++ b/tests/spec/search.spec.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+/* global browser, describe, it */
+
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+var protractor = require('protractor');
+var EC = protractor.ExpectedConditions;
+
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+
+describe('search', function () {
+    it('should perform a search', function () {
+        browser.get(browser.baseUrl);
+        expect(browser.getTitle()).to.eventually.match(/Fluxible/);
+
+        // click the search icon to show the search
+        $('.fa-search').click();
+
+        // enter search term
+        var searchInput = $('input[name="q"]');
+        searchInput.sendKeys('context');
+        searchInput.sendKeys(protractor.Key.ENTER);
+
+        // get the main container to ensure search was performed
+        var h1 = $('#main h1');
+        browser.wait(EC.presenceOf(h1), 500);
+
+        // grab search results container
+        var searchResults = $$('#main ol li');
+        browser.wait(EC.presenceOf(searchResults.get(0)), 500);
+
+        // ensure the search page was viewed
+        expect(h1.getText()).to.eventually.match(/Search Results/);
+
+        // this ensures there are some search results, without
+        // needing to assert what the results are
+        expect(searchResults.count()).to.eventually.be.above(1);
+    });
+});

--- a/tests/unit/actions/demoException.js
+++ b/tests/unit/actions/demoException.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+/* global describe, it, beforeEach */
+'use strict';
+import { expect } from 'chai';
+import { createMockActionContext } from 'fluxible/utils';
+import demoException from '../../../actions/demoException';
+
+describe('demo exception', function () {
+    let context;
+
+    beforeEach(function () {
+        context = createMockActionContext();
+    });
+
+    it('should execute the action', function (done) {
+        demoException(context, {}, function (err) {
+            expect(err).to.eql(new Error('Whoops!'));
+            done();
+        });
+    });
+});
+

--- a/tests/unit/actions/doSearch.js
+++ b/tests/unit/actions/doSearch.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+/* global describe, it, beforeEach */
+'use strict';
+import Immutable from 'immutable';
+import { expect } from 'chai';
+import { createMockActionContext } from 'fluxible/utils';
+import doSearch from '../../../actions/doSearch';
+
+describe('do search', function () {
+    let context;
+
+    beforeEach(function () {
+        context = createMockActionContext();
+    });
+
+    it('should execute the action', function (done) {
+        doSearch(context, 'query', function () {
+            expect(context.dispatchCalls.length).to.equal(1);
+            expect(context.dispatchCalls[0].name).to.equal('DO_SEARCH');
+            expect(context.dispatchCalls[0].payload).to.equal('query');
+            done();
+        });
+    });
+});
+

--- a/tests/unit/actions/loadIndex.js
+++ b/tests/unit/actions/loadIndex.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+/* global describe, it, beforeEach */
+'use strict';
+import Immutable from 'immutable';
+import { expect } from 'chai';
+import { createMockActionContext } from 'fluxible/utils';
+import MockService from 'fluxible-plugin-fetchr/utils/MockServiceManager';
+import SearchStore from '../../../stores/SearchStore';
+import loadIndex from '../../../actions/loadIndex';
+import mockIndex from '../../fixtures/index.json';
+
+describe('load index', function () {
+    let context;
+
+    beforeEach(function () {
+        context = createMockActionContext({
+            stores: [SearchStore]
+        });;
+        context.service = new MockService();
+        context.service.setService('search', function (method, params, config, callback) {
+            callback(null, mockIndex);
+        });
+    });
+
+    it('should load index from the service', function (done) {
+        context.executeAction(loadIndex, {}, function () {
+            expect(context.dispatchCalls.length).to.equal(1);
+            expect(context.dispatchCalls[0].name).to.equal('RECEIVE_INDEX');
+            expect(context.dispatchCalls[0].payload).to.eql(mockIndex);
+            done();
+        });
+    });
+});
+

--- a/tests/unit/actions/showSearch.js
+++ b/tests/unit/actions/showSearch.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+/* global describe, it, beforeEach */
+'use strict';
+import Immutable from 'immutable';
+import { expect } from 'chai';
+import { createMockActionContext } from 'fluxible/utils';
+import showSearch from '../../../actions/showSearch';
+
+describe('show search', function () {
+    let context;
+
+    beforeEach(function () {
+        context = createMockActionContext();
+    });
+
+    it('should execute the action', function (done) {
+        const route = Immutable.fromJS({}).withMutations(function (r) {
+            r.set('query', Immutable.fromJS({q: 'foo'}));
+        });
+
+        showSearch(context, route, function () {
+            expect(context.dispatchCalls.length).to.equal(1);
+            expect(context.dispatchCalls[0].name).to.equal('DO_SEARCH');
+            expect(context.dispatchCalls[0].payload).to.equal('foo');
+            done();
+        });
+    });
+});
+

--- a/tests/unit/stores/SearchStore.js
+++ b/tests/unit/stores/SearchStore.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+/* global describe, it, beforeEach, afterEach */
+'use strict';
+import {expect} from 'chai';
+import SearchStore from '../../../stores/SearchStore';
+import mockIndex from '../../fixtures/index.json';
+
+describe('doc store', function () {
+    let storeInstance;
+
+    beforeEach(function () {
+        storeInstance = new SearchStore();
+    });
+
+    afterEach(function () {
+        storeInstance = undefined;
+    });
+
+    it('should instantiate correctly', function () {
+        expect(storeInstance).to.be.an('object');
+        expect(storeInstance.docs).to.be.null;
+        expect(storeInstance.index).to.be.null;
+        expect(storeInstance.query).to.be.null;
+        expect(storeInstance.results).to.be.an('array');
+    });
+
+    it('should receive index', function () {
+        storeInstance._receiveIndex(mockIndex);
+        expect(Object.keys(storeInstance.docs).length).to.equal(1);
+    });
+
+    it('should get the docs', function () {
+        storeInstance._receiveIndex(mockIndex);
+        const docKey = mockIndex.docs[0].id;
+        const docs = storeInstance.getDocs();
+        expect(storeInstance.getDocs()).to.be.an('object');
+        expect(storeInstance.getDocs()[docKey]).to.eql(mockIndex.docs[0]);
+    });
+
+    it('should get the index', function () {
+        storeInstance._receiveIndex(mockIndex);
+        expect(storeInstance.getIndex()).to.be.an('object');
+    });
+
+    it('should get the query', function () {
+        const query = 'foo';
+        storeInstance._receiveIndex(mockIndex);
+        storeInstance._doSearch(query);
+        expect(storeInstance.getQuery()).to.equal(query);
+    });
+
+    it('should get the store state', function (done) {
+        storeInstance._receiveIndex(mockIndex);
+        const state = storeInstance.getState();
+
+        expect(state.docs).to.be.an('object');
+        expect(state.index).to.be.an('object');
+        done();
+    });
+});
+


### PR DESCRIPTION
@lingyan @mridgway @Vijar 

Fixes #78. This PR provides support for client side search using [lunrjs](http://lunrjs.com/). Read below to see how it works.

## Creating the index
On server start, the `docs service` creates a lunr.js index and adds each markdown document to the index. The index is then serialized and saved to the `/build/search.json` file, so it can be used on the client (its about ~1mb, maybe too large to dehydrate from a store). 

## Loading the index
On the client, the new `Search.jsx` component has a `componentDidMount` lifecycle event which fires a `LOAD_INDEX` action. This action will call the `search service`. The `search service` reads the `/build/search.json` lunr.js index file and returns that to the action. The `RECEIVE_INDEX` action is then fired, with this payload. The `SearchStore` listens to `RECEIVE_INDEX` and stores the index in the store.

## Performing a search
The `Search.jsx` component contains an input field that is displayed when the search icon is clicked. After the search query is inputed and `ENTER` is pressed, the `navigateAction` event is fired to load the new `/search.html` page (we use the `navigateAction` to save the query in the browser history). The `/search.html` route uses the `showSearch` action to fire the `DO_SEARCH` action (with query passed for the payload). The `SearchStore` uses the query to perform a search on the lunr.js index. State is stored and `emitChange` is called. The `Docs` component listens to change events from the `SearchStore` and renders the `SearchResults` component to display search results.

## Watch it in action
https://www.youtube.com/watch?v=kCqa2ELcG4Y

## Todo
- [x] Unit tests
- [x] Functional tests
