### PR TITLE
Fixes #128 by recognizing relative paths in link replacements

### DIFF
--- a/services/docs.js
+++ b/services/docs.js
@@ -50,7 +50,7 @@ let fetchAPI = function (docParams, cb) {
             let output = marked(mdString, {renderer: renderer});
 
             // Replace links
-            let internalLinkRegex = /href="([a-zA-Z\/\-]*\.md)/g;
+            let internalLinkRegex = /href="([a-zA-Z\/\-\.]*\.md)/g;
             let replacements = [];
             let result;
 


### PR DESCRIPTION
When finding internal page links to replace .md links with the configured route paths, parent directory links were not matching because "../" wasn't handled in the regexp.