### PR TITLE
apply react-i13n for instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ $ npm install
 
 There is also a `/secrets.example.js` file that you need to copy to `/secrets.js` with your GitHub API credentials to allow the app to access the page content it needs from GitHub.
 
-
 ## Run the app
 
 ```bash

--- a/components/Application.jsx
+++ b/components/Application.jsx
@@ -9,11 +9,14 @@ import React from 'react';
 import Home from './Home.jsx';
 import Docs from './Docs.jsx';
 import { provideContext, connectToStores } from 'fluxible/addons';
-import { handleHistory, NavLink } from 'fluxible-router';
+import { handleHistory } from 'fluxible-router';
+import NavLink from './NavLink.jsx';
 import TopNav from './TopNav';
 import Status404 from './Status404';
 import Status500 from './Status500';
 import cx from 'classnames';
+import { ReactI13n, setupI13n, I13nAnchor } from 'react-i13n';
+import ReactI13nGoogleAnalytics from 'react-i13n-ga';
 
 const debug = Debug('MyApp');
 
@@ -21,18 +24,17 @@ class Application extends React.Component {
     shouldComponentUpdate(nextProps, nextState) {
         return nextProps.isNavigateComplete;
     }
+    
+    componentDidMount() {
+        ReactI13n.getInstance().execute('pageview', {});
+    }
 
     componentDidUpdate(prevProps, prevState) {
+        ReactI13n.getInstance().execute('pageview', {
+            page: this.props.currentRoute && this.props.currentRoute.get('url'),
+            title: this.props.currentTitle
+        });
         document.title = this.props.currentTitle;
-
-        // log pageview
-        if (ga) {
-            ga('set', {
-                page: this.props.currentRoute && this.props.currentRoute.get('url'),
-                title: this.props.currentTitle
-            });
-            ga('send', 'pageview');
-        }
     }
 
     render() {
@@ -63,7 +65,7 @@ class Application extends React.Component {
                 <div className="wrapper Bxz(bb) Mih(100%)">
                     <div id="header" role="header" className="Px(10px) Py(13px) Ov(h) Z(7) Pos(r) Bgc(logo) optLegibility">
                         <div className="innerwrapper spaceBetween Mx(a)--sm W(90%)--sm W(a)--sm">
-                            <NavLink className={logoClasses} routeName="home" style={{ fontFamily: 'Montserrat' }}>
+                            <NavLink className={logoClasses} routeName="home" style={{ fontFamily: 'Montserrat' }} i13nModel={{category: 'logo'}}>
                                 <img src="/public/images/logo_small.svg" width="16" height="16" alt="Fluxible" style={{verticalAlign: 'baseline'}} /> Fluxible
                             </NavLink> <TopNav selected={routeName} currentRoute={this.props.currentRoute} />
                         </div>
@@ -72,7 +74,7 @@ class Application extends React.Component {
                 </div>
                 <div id="footer" className="P(20px) Bdt(1)" role="footer">
                     <div className="innerwrapper spaceBetween Mx(a)--sm W(90%)--sm W(a)--sm">
-                        <small>All code on this site is licensed under the <a href="https://github.com/yahoo/fluxible.io/blob/master/LICENSE.md">Yahoo BSD License</a>, unless otherwise stated.</small> <small>&copy; 2015 Yahoo! Inc. All rights reserved.</small>
+                        <small>All code on this site is licensed under the <I13nAnchor i13nModel={{category: 'license'}} href="https://github.com/yahoo/fluxible.io/blob/master/LICENSE.md">Yahoo BSD License</I13nAnchor>, unless otherwise stated.</small> <small>&copy; 2015 Yahoo! Inc. All rights reserved.</small>
                     </div>
                 </div>
             </div>
@@ -93,5 +95,9 @@ Application = handleHistory(Application);
 
 // and wrap that with context
 Application = provideContext(Application);
+
+// setup i13n
+var reactI13nGoogleAnalytics = new ReactI13nGoogleAnalytics('UA-58912168-1');
+Application = setupI13n(Application, {}, [reactI13nGoogleAnalytics.getPlugin()]);
 
 export default Application;

--- a/components/Doc.jsx
+++ b/components/Doc.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import { navigateAction } from 'fluxible-router';
+import { ReactI13n, I13nAnchor } from 'react-i13n';
 
 const DOCS_URL = 'https://github.com/yahoo/fluxible/tree/master';
 
@@ -17,6 +18,7 @@ function isModifiedEvent (e) {
 }
 
 class Doc extends React.Component {
+
     onClick(e) {
         let target = e.target;
 
@@ -38,11 +40,11 @@ class Doc extends React.Component {
 
         if (this.props.currentRoute && this.props.currentRoute.get('githubPath') !== -1) {
             editEl = (
-                <a href={DOCS_URL + this.props.currentRoute.get('githubPath')}
+                <I13nAnchor href={DOCS_URL + this.props.currentRoute.get('githubPath')}
                     className="edit-github Pos(a) End(10px) T(18px)"
                     target="_blank">
                     Edit on Github
-                </a>
+                </I13nAnchor>
             );
         }
 

--- a/components/Home.jsx
+++ b/components/Home.jsx
@@ -4,7 +4,8 @@
  */
 
 import React from 'react';
-import { NavLink } from 'fluxible-router';
+import NavLink from './NavLink.jsx';
+import { I13nAnchor, createI13nNode } from 'react-i13n';
 import { connectToStores } from 'fluxible/addons';
 import Doc from './Doc.jsx';
 
@@ -24,7 +25,7 @@ class Home extends React.Component {
                     </div>
                     <div className="Pos(a) End(10px) B(5px) C(eee) Fz(80%)">
                         <cite>
-                            <a href="https://www.flickr.com/photos/devinmoore/2670474853" title="Splash derived from Blue Ring Electricity Fractal by Devin Moore used under CC BY 2.0" _target="blank">&copy; Devon Moore</a>
+                            <I13nAnchor href="https://www.flickr.com/photos/devinmoore/2670474853" title="Splash derived from Blue Ring Electricity Fractal by Devin Moore used under CC BY 2.0" _target="blank">&copy; Devon Moore</I13nAnchor>
                         </cite>
                     </div>
                 </div>
@@ -79,14 +80,14 @@ class Home extends React.Component {
                     </div>
 
                     <p className="Ta(c) Mt(2em)--sm">
-                        <a href="https://gitter.im/yahoo/fluxible">
+                        <I13nAnchor href="https://gitter.im/yahoo/fluxible">
                             <img src="https://camo.githubusercontent.com/20d7543bc8280bf8134b686c46c7b7e2c0a467fd/68747470733a2f2f6261646765732e6769747465722e696d2f67697474657248512f6769747465722e706e67"
                                 alt="Gitter chat"
                                 data-canonical-src="https://badges.gitter.im/gitterHQ/gitter.png"
                                 style={{maxWidth: "100%"}}
                                 className="Va(m)" />
-                        </a> or
-                        #fluxible channel of the <a href="http://reactiflux.com/">Reactiflux</a> Slack community.
+                        </I13nAnchor> or
+                        #fluxible channel of the <I13nAnchor href="http://reactiflux.com/">Reactiflux</I13nAnchor> Slack community.
                     </p>
 
                     <div className="Ta(c)">
@@ -98,4 +99,6 @@ class Home extends React.Component {
     }
 }
 
-export default Home;
+export default createI13nNode(Home, {
+    i13nModel: {category: 'home'}
+});

--- a/components/Menu.jsx
+++ b/components/Menu.jsx
@@ -5,7 +5,8 @@
 
 import React from 'react/addons';
 import cx from 'classnames';
-import { NavLink } from 'fluxible-router';
+import NavLink from './NavLink.jsx';
+import { createI13nNode } from 'react-i13n';
 import docsConfig from './../configs/menu';
 
 class Menu extends React.Component {
@@ -52,4 +53,6 @@ class Menu extends React.Component {
     }
 }
 
-export default Menu;
+export default createI13nNode(Menu, {
+    i13nModel: {category: 'menu'}
+});

--- a/components/NavLink.jsx
+++ b/components/NavLink.jsx
@@ -1,0 +1,10 @@
+import { createI13nNode } from 'react-i13n';
+import { NavLink } from 'fluxible-router';
+
+var I13nNavLink = createI13nNode(NavLink, {
+    isLeafNode: true,
+    bindClickEvent: true,
+    follow: false
+});
+
+export default I13nNavLink;

--- a/components/Status404.jsx
+++ b/components/Status404.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { NavLink } from 'fluxible-router';
+import NavLink from './NavLink.jsx';
 
 class Status404 extends React.Component {
     render() {
@@ -14,7 +14,7 @@ class Status404 extends React.Component {
                     <div className="Mx(a) W(65%) Pos(r) Ov(h) Fw(300)">
                         <h1>Not found</h1>
                         <p>Sorry we could not find that resource.</p>
-                        <p><NavLink routeName="home">Back to the home page.</NavLink></p>
+                        <p><NavLink routeName="home" i13nModel={{category: '404'}}>Back to the home page.</NavLink></p>
                     </div>
                 </div>
             </div>

--- a/components/Status500.jsx
+++ b/components/Status500.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { NavLink } from 'fluxible-router';
+import NavLink from './NavLink.jsx';
 
 class Status500 extends React.Component {
     render() {
@@ -14,7 +14,7 @@ class Status500 extends React.Component {
                     <div className="Mx(a) W(65%) Pos(r) Ov(h) Fw(300)">
                         <h1>Error</h1>
                         <p>Sorry there was an unexpected errror.</p>
-                        <p><NavLink routeName="home">Back to the home page.</NavLink></p>
+                        <p><NavLink routeName="home" i13nModel={{category: '500'}}>Back to the home page.</NavLink></p>
                     </div>
                 </div>
             </div>

--- a/components/TopNav.jsx
+++ b/components/TopNav.jsx
@@ -4,8 +4,9 @@
  */
 
 import React from 'react';
-import { NavLink } from 'fluxible-router';
 import cx from 'classnames';
+import NavLink from './NavLink.jsx';
+import { I13nAnchor, createI13nNode } from 'react-i13n'
 import Search from './Search.jsx'
 
 class TopNav extends React.Component {
@@ -27,9 +28,9 @@ class TopNav extends React.Component {
                     </NavLink>
                 </li>
                 <li className="D(ib) Va(m) Mstart(20px) Pos(r) Fw(400)">
-                    <a href="https://github.com/yahoo/fluxible" className="D(b) C(#fff) Td(n):h navLink" target="_blank">
+                    <I13nAnchor href="https://github.com/yahoo/fluxible" className="D(b) C(#fff) Td(n):h navLink" target="_blank">
                         <i className="Va(m) Pos(r) fa fa-github"></i> GitHub
-                    </a>
+                    </I13nAnchor>
                 </li>
             </ul>
         );
@@ -41,4 +42,6 @@ TopNav.propTypes = {
     selected: React.PropTypes.string
 };
 
-export default TopNav;
+export default createI13nNode(TopNav, {
+    i13nModel: {category: 'top-nav'}
+});

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "lunr": "^0.5.9",
     "marked": "^0.3.3",
     "react": "^0.13.0",
+    "react-i13n": "^0.1.11",
+    "react-i13n-ga": "^0.1.0",
     "serialize-javascript": "^1.0.0",
     "serve-favicon": "^2.1.6",
     "superagent": "^1.2.0"

--- a/server.js
+++ b/server.js
@@ -13,7 +13,6 @@ import csrf from 'csurf';
 import React from 'react';
 import app from './app';
 import html from './components/Html.jsx';
-import tracking from './configs/tracking';
 import assets from './utils/assets';
 import DocsService from './services/docs';
 import SearchService from './services/search';
@@ -49,8 +48,7 @@ function renderApp(res, context) {
         assets: assets,
         context: componentContext,
         state: exposed,
-        markup: renderedApp,
-        tracking: tracking
+        markup: renderedApp
     }));
 
     res.send(doctype + html);


### PR DESCRIPTION
created `react-i13n-ga`
https://github.com/kaesonho/react-i13n-ga
https://www.npmjs.com/package/react-i13n-ga

apply `react-i13n` and 
1. send out pageview beacon 
2. send out click beacon(event beacon https://developers.google.com/analytics/devguides/collection/analyticsjs/events). 
pv works as usual and we can see the event report for clicks in google analytics. 

@redonkulus @mridgway @lingyan @Vijar 