### PR TITLE
align with latest react-i13n code, add link scan for doc links

### DIFF
--- a/components/Application.jsx
+++ b/components/Application.jsx
@@ -26,11 +26,11 @@ class Application extends React.Component {
     }
     
     componentDidMount() {
-        ReactI13n.getInstance().execute('pageview', {});
+        this.props.i13n.executeEvent('pageview', {});
     }
 
     componentDidUpdate(prevProps, prevState) {
-        ReactI13n.getInstance().execute('pageview', {
+        this.props.i13n.executeEvent('pageview', {
             page: this.props.currentRoute && this.props.currentRoute.get('url'),
             title: this.props.currentTitle
         });

--- a/components/Doc.jsx
+++ b/components/Doc.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { navigateAction } from 'fluxible-router';
-import { ReactI13n, I13nAnchor } from 'react-i13n';
+import { ReactI13n, createI13nNode, I13nAnchor, I13nDiv} from 'react-i13n';
 
 const DOCS_URL = 'https://github.com/yahoo/fluxible/tree/master';
 
@@ -53,7 +53,7 @@ class Doc extends React.Component {
         return (
             <div id="main" role="main" className="D(tbc)--sm Px(10px) Pos(r)">
                 {editEl}
-                <div onClick={this.onClick.bind(this)} dangerouslySetInnerHTML={{__html: markup}}></div>
+                <I13nDiv key={new Date().getTime()} onClick={this.onClick.bind(this)} dangerouslySetInnerHTML={{__html: markup}} scanLinks={{enable: true}}></I13nDiv>
             </div>
         );
     }
@@ -68,4 +68,6 @@ Doc.propTypes = {
     currentRoute: React.PropTypes.object.isRequired
 };
 
-export default Doc;
+export default createI13nNode(Doc, {
+    i13nModel: {category: 'doc'}
+});


### PR DESCRIPTION
align with latest react-i13n interface, also add the auto scan features, now we can track the links inside `dangerouslySetInnerHTML `
@redonkulus @mridgway @Vijar 