### PR TITLE
update to pull docs from multiple repositories

### DIFF
--- a/components/Doc.jsx
+++ b/components/Doc.jsx
@@ -7,7 +7,10 @@ import React from 'react';
 import { navigateAction } from 'fluxible-router';
 import { ReactI13n, createI13nNode, I13nAnchor, I13nDiv} from 'react-i13n';
 
-const DOCS_URL = 'https://github.com/yahoo/fluxible/tree/master';
+function createDocsUrl(repo, path) {
+    repo = repo || 'yahoo/fluxible';
+    return 'https://github.com/' + repo + '/tree/master' + path;
+}
 
 function isLeftClickEvent (e) {
     return e.button === 0;
@@ -40,7 +43,7 @@ class Doc extends React.Component {
 
         if (this.props.currentRoute && this.props.currentRoute.get('githubPath') !== -1) {
             editEl = (
-                <I13nAnchor href={DOCS_URL + this.props.currentRoute.get('githubPath')}
+                <I13nAnchor href={createDocsUrl(this.props.currentRoute.get('githubRepo'), this.props.currentRoute.get('githubPath'))}
                     className="edit-github Pos(a) End(10px) T(18px)"
                     target="_blank">
                     Edit on Github

--- a/configs/routes.js
+++ b/configs/routes.js
@@ -17,6 +17,7 @@ export default {
         method: 'GET',
         handler: Home,
         githubPath: '/docs/home.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitle: 'Fluxible | A Pluggable Container for Isomorphic Flux Applications',
         pageDescription: 'A Pluggable Container for Isomorphic Flux Applications'
@@ -26,6 +27,7 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/quick-start.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'Quick Start',
         pageDescription: 'Get started with Fluxible by using our generator to setup your application.'
@@ -35,6 +37,7 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/faq.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'FAQ',
         pageDescription: 'Frequently asked questions from the community.'
@@ -59,6 +62,7 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/api/Actions.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'API: Actions',
         pageDescription: 'Actions (called "action creators" in Flux) in Fluxible are stateless async functions.'
@@ -68,6 +72,7 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/api/Components.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'API: Components',
         pageDescription: 'React components able to access the state of the application that is held within stores ' +
@@ -78,6 +83,7 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/api/Fluxible.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'API: Fluxible',
         pageDescription: 'Instantiated once for your application, this holds settings and interfaces' +
@@ -88,6 +94,7 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/api/FluxibleContext.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'API: FluxibleContext',
         pageDescription: 'Instantiated once per request/session, this container provides isolation of ' +
@@ -98,6 +105,7 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/api/Plugins.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'API: Plugins',
         pageDescription: 'Plugins allow you to extend the interface of each context type.'
@@ -107,6 +115,7 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/api/Stores.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'API: Stores',
         pageDescription: 'Flux stores are where you keep your application\'s state and ' +
@@ -115,19 +124,21 @@ export default {
 
     // Addons
     baseStore: {
-        path: '/api/addons/BaseStore.html',
+        path: '/addons/BaseStore.html',
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/api/addons/BaseStore.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'API: addons/BaseStore',
         pageDescription: 'A base class that you can extend to reduce boilerplate when creating stores.'
     },
     fluxibleComponent: {
-        path: '/api/addons/FluxibleComponent.html',
+        path: '/addons/FluxibleComponent.html',
         method: 'GET',
         handler: Docs,
-        githubPath: '/docs/api/addons/FluxibleComponent.md',
+        githubPath: '/docs/api/FluxibleComponent.md',
+        githubRepo: 'yahoo/fluxible-addons-react',
         action: showDoc,
         pageTitlePrefix: 'API: addons/FluxibleComponent',
         pageDescription: 'The FluxibleComponent is a wrapper component that will provide all' +
@@ -135,39 +146,55 @@ export default {
             ' childContextTypes and getChildContext.'
     },
     fluxibleMixin: {
-        path: '/api/addons/FluxibleMixin.html',
+        path: '/addons/FluxibleMixin.html',
         method: 'GET',
         handler: Docs,
-        githubPath: '/docs/api/addons/FluxibleMixin.md',
+        githubPath: '/docs/api/FluxibleMixin.md',
+        githubRepo: 'yahoo/fluxible-addons-react',
         action: showDoc,
         pageTitlePrefix: 'API: addons/FluxibleMixin',
         pageDescription: 'The mixin will add the contextTypes getStore and executeAction to your component.'
     },
     connectToStores: {
-        path: '/api/addons/connectToStores.html',
+        path: '/addons/connectToStores.html',
         method: 'GET',
         handler: Docs,
-        githubPath: '/docs/api/addons/connectToStores.md',
+        githubPath: '/docs/api/connectToStores.md',
+        githubRepo: 'yahoo/fluxible-addons-react',
         action: showDoc,
         pageTitlePrefix: 'API: addons/connectToStores',
         pageDescription: 'connectToStores is a higher-order component that provides a convenient way' +
             ' to access state from the stores from within your component'
     },
+    createElementWithContext: {
+        path: '/addons/createElementWithContext.html',
+        method: 'GET',
+        handler: Docs,
+        githubPath: '/docs/api/createElementWithContext.md',
+        githubRepo: 'yahoo/fluxible-addons-react',
+        action: showDoc,
+        pageTitlePrefix: 'API: addons/createElementWithContext',
+        pageDescription: 'Convenience method for instantiating the Fluxible app\'s ' +
+            'top level React component (if provided in the constructor) with the given' +
+            'props with an additional context key containing a ComponentContext.'
+    },
     createStore: {
-        path: '/api/addons/createStore.html',
+        path: '/addons/createStore.html',
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/api/addons/createStore.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'API: addons/createStore',
         pageDescription: 'A helper method similar to React.createClass but for creating stores that' +
             ' extend BaseStore. Also supports mixins.'
     },
     provideContext: {
-        path: '/api/addons/provideContext.html',
+        path: '/addons/provideContext.html',
         method: 'GET',
         handler: Docs,
-        githubPath: '/docs/api/addons/provideContext.md',
+        githubPath: '/docs/api/provideContext.md',
+        githubRepo: 'yahoo/fluxible-addons-react',
         action: showDoc,
         pageTitlePrefix: 'API: addons/provideContext',
         pageDescription: 'provideContext wraps the Component with a higher-order component' +
@@ -180,19 +207,11 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/tutorials/routing.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'Routing Tutorial',
         pageDescription: 'A tutorial covering the concepts of building an isomorphic website' +
             ' with Fluxible that demonstrates routing.'
-    },
-    isomorphicFlux: {
-        path: '/api/bringing-flux-to-the-server.html',
-        method: 'GET',
-        handler: Docs,
-        githubPath: '/docs/guides/bringing-flux-to-the-server.md',
-        action: showDoc,
-        pageTitlePrefix: 'Bringing Flux to the Server',
-        pageDescription: 'An in depth look at how Flux was brought to the server.'
     },
 
     // Guides
@@ -201,10 +220,21 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/guides/data-services.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'Data Services Guide',
         pageDescription: 'Services are where you define your CRUD operations for a' +
             ' specific resource. A resource is a unique string that identifies the data.'
+    },
+    isomorphicFlux: {
+        path: '/guides/bringing-flux-to-the-server.html',
+        method: 'GET',
+        handler: Docs,
+        githubPath: '/docs/guides/bringing-flux-to-the-server.md',
+        githubRepo: 'yahoo/fluxible',
+        action: showDoc,
+        pageTitlePrefix: 'Bringing Flux to the Server',
+        pageDescription: 'An in depth look at how Flux was brought to the server.'
     },
 
     // Community
@@ -213,6 +243,7 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/community/libraries.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'Community Libraries',
         pageDescription: 'Take a look at some of the libraries that our community has built.'
@@ -222,6 +253,7 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/community/presentations.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'Community Presentations',
         pageDescription: 'Presentations we have given to the community.'
@@ -231,10 +263,13 @@ export default {
         method: 'GET',
         handler: Docs,
         githubPath: '/docs/community/reference-applications.md',
+        githubRepo: 'yahoo/fluxible',
         action: showDoc,
         pageTitlePrefix: 'Community Reference Applications',
         pageDescription: 'Applications using Fluxible in the wild.'
     },
+
+    // Status pages
     status404: {
         path: '/__http404',
         handler: Status404

--- a/secrets.example.js
+++ b/secrets.example.js
@@ -2,9 +2,15 @@
  * This is a sample file for your Github client id and client secret
  * This is needed to collect the doc's from the fluxible repo.
  * You can generate the client/secret pair here: https://github.com/settings/applications/new
+ *
+ * Alternatively, you can pass in an oauth access token to work around the rate limiting
+ * restrictions of the client id / secret pair
+ *
+ * GitHub Auth docs: https://developer.github.com/v3/#authentication
  */
 export default {
     github: {
+        accessToken: process.env.GITHUB_ACCESS_TOKEN || '',
         clientId: process.env.GITHUB_CLIENT_ID || '',
         clientSecret: process.env.GITHUB_CLIENT_SECRET || ''
     }

--- a/services/docs.js
+++ b/services/docs.js
@@ -3,21 +3,21 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
+import async from 'async';
 import debugLib from 'debug';
-import marked from 'marked';
+import fs from 'fs';
+import getSearchIndexPath from '../utils/getSearchIndexPath';
 import highlight from 'highlight.js';
+import lunr from 'lunr';
+import marked from 'marked';
+import qs from 'querystring';
 import renderer from './../utils/renderer';
 import request from 'superagent';
-import secrets from './../secrets';
-import qs from 'querystring';
-import url from 'url';
 import routes from '../configs/routes';
-import fs from 'fs';
-import lunr from 'lunr';
-import async from 'async';
-import getSearchIndexPath from '../utils/getSearchIndexPath';
+import secrets from './../secrets';
+import url from 'url';
 
-const debug = debugLib('APIService');
+const debug = debugLib('DocsService');
 const indexDb = getSearchIndexPath();
 
 marked.setOptions({
@@ -39,17 +39,33 @@ const index = lunr(function () {
     this.field('permalink');
 });
 
-let fetchAPI = function (docParams, cb) {
+const fetchAPI = function (docParams, cb) {
     const title = docParams.pageTitlePrefix || docParams.pageTitle;
     const description = docParams.pageDescription;
-    const githubRepo = docParams.repo || 'yahoo/fluxible';
+    const githubRepo = docParams.githubRepo || 'yahoo/fluxible';
     const githubPath = docParams.githubPath;
+
+    // create github api url
     let githubUrl = 'https://api.github.com/repos/' + githubRepo + '/contents/';
-    githubUrl += githubPath;
-    githubUrl += '?' + qs.stringify({
-        client_id: secrets.github.clientId,
-        client_secret: secrets.github.clientSecret
-    });
+    githubUrl += githubPath + '?';
+
+    // use access token if available, otherwise use client id and secret
+    if (secrets.github.accessToken) {
+        githubUrl += qs.stringify({
+            access_token: secrets.github.accessToken
+        });
+    } else {
+        githubUrl += qs.stringify({
+            client_id: secrets.github.clientId,
+            client_secret: secrets.github.clientSecret
+        });
+    }
+
+    // add tag from npm version
+    if (docParams.githubTag) {
+        githubUrl += '&ref=' + docParams.githubTag;
+    }
+    debug(githubUrl);
 
     request
     .get(githubUrl)
@@ -66,12 +82,12 @@ let fetchAPI = function (docParams, cb) {
 
             let output = marked(mdString, {renderer: renderer});
 
-            // Replace links
-            let internalLinkRegex = /href="([a-zA-Z\/\-\.]*\.md)/g;
+            // Replace all .md links
+            let linkRegex = /href="([^\"]+\.md)"/g;
             let replacements = [];
             let result;
 
-            while ((result = internalLinkRegex.exec(output)) !== null) {
+            while ((result = linkRegex.exec(output)) !== null) {
                 // Get the relative github path to link
                 let fixedRelativePath = url.resolve(githubPath, result[1]);
                 let matchedDoc;
@@ -80,7 +96,12 @@ let fetchAPI = function (docParams, cb) {
                 /*jshint ignore:start */
                 Object.keys(routes).forEach((routeName) => {
                     let routeConfig = routes[routeName];
-                    if (fixedRelativePath === routeConfig.githubPath) {
+
+                    if (
+                        (fixedRelativePath === routeConfig.githubPath) ||
+                        // support absolute urls of links from different repositories
+                        (result[1].indexOf('http') !== -1 && result[1].indexOf(routeConfig.githubPath) !== -1)
+                    ) {
                         matchedDoc = routeConfig;
                         return;
                     }
@@ -118,7 +139,7 @@ let fetchAPI = function (docParams, cb) {
 
             return cb(null, cache[githubPath]);
         } else {
-            debug('Doc not found for', githubPath, res.body);
+            console.error('Doc not found for', githubPath, res.body);
 
             cache[githubPath] = {
                 key: githubPath,
@@ -130,24 +151,79 @@ let fetchAPI = function (docParams, cb) {
     });
 };
 
-(function refreshCacheFromGithub() {
-    var fetches = [];
-    Object.keys(routes).forEach(function (routeName) {
-        if (routes[routeName].githubPath) {
-            fetches.push(function(cb) {
-                fetchAPI(routes[routeName], cb);
-            });
+const fetchNpm = function (pkg, cb) {
+    var url = 'http://registry.npmjs.org/' + pkg;
+    debug(url);
+
+    request
+    .get(url)
+    .end(function (err, res) {
+        let version;
+
+        if (err || !res) {
+            return cb(new Error('npm request failed: ' + url));
         }
+
+        if (res.body && res.body['dist-tags']) {
+            version = res.body['dist-tags'].latest;
+        }
+
+        cb(null, version);
     });
+};
 
-    async.parallel(fetches, function(err) {
-        // save index
-        const data = {
-            docs: documents,
-            index: index.toJSON()
-        };
+/*
+ Steps
+ 1. Call npm API to return version for fluxible and fluxible-addons-react
+ 2. Uses these versions to make GitHub API calls for docs content
+ */
+(function refreshCacheFromGithub() {
+    var versionHash = {
+        'yahoo/fluxible': null,
+        'fluxible-addons-react': null
+    };
+    async.auto({
+        fluxibleVersion: function (cb) {
+            fetchNpm('fluxible', cb);
+        },
+        fluxibleAddonsVersion: function (cb) {
+            fetchNpm('fluxible-addons-react', cb);
+        },
+        fetchAPI: ['fluxibleVersion', 'fluxibleAddonsVersion', function (cb, results) {
+            debug('fetchAPI version results', results);
 
-        fs.writeFileSync(indexDb, JSON.stringify(data));
+            const fetches = [];
+            versionHash['yahoo/fluxible'] = results.fluxibleVersion;
+            versionHash['yahoo/fluxible-addons-react'] = results.fluxibleAddonsVersion;
+
+            Object.keys(routes).forEach(function eachRoute(routeName) {
+                let routeConfig = routes[routeName];
+
+                // pass npm version depending on repo source to only pull
+                // content for that tag
+                routeConfig.githubTag = 'v' + versionHash[routeConfig.githubRepo];
+
+                if (routeConfig.githubPath) {
+                    fetches.push(function eachTask(cb) {
+                        fetchAPI(routeConfig, cb);
+                    });
+                }
+            });
+
+            async.parallel(fetches, function npmFetchesCallback(err) {
+                if (err) {
+                    return console.error(err);
+                }
+
+                // save index
+                const data = {
+                    docs: documents,
+                    index: index.toJSON()
+                };
+
+                fs.writeFileSync(indexDb, JSON.stringify(data));
+            });
+        }]
     });
 
     setTimeout(refreshCacheFromGithub, 60 * 60 * 1000); // refresh cache every hour


### PR DESCRIPTION
@lingyan @Vijar 

Fixes #138 and now pulls the addons docs from the fluxible-addons-react repository. Once this is merged we can do an alpha release of fluxible 0.5.

### Notes
- Added `secrets.github.accessToken` to get around GitHub API rate limit when using only client id and secret. accessToken doesn't have a limit so its easier to test when making so many calls for docs.
- Added `githubRepo` property to routes to denote different repo, if left out, will just use `yahoo/fluxible`.
- Added support to part absolute URLs in markdown, as doc links across repo's will need to be absolute URLs.