### PR TITLE
Use github branch for docs versioning instead of tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react": "^0.13.0",
     "react-i13n": "^0.1.11",
     "react-i13n-ga": "^0.1.0",
+    "semver": "^4.3.6",
     "serialize-javascript": "^1.0.0",
     "serve-favicon": "^2.1.6",
     "superagent": "^1.2.0"

--- a/services/docs.js
+++ b/services/docs.js
@@ -16,6 +16,7 @@ import request from 'superagent';
 import routes from '../configs/routes';
 import secrets from './../secrets';
 import url from 'url';
+import semver from 'semver';
 
 const debug = debugLib('DocsService');
 const indexDb = getSearchIndexPath();
@@ -26,7 +27,7 @@ marked.setOptions({
     }
 });
 
-// Generate an hash of valid api routes, from the /configs/apis.js file
+// Generate a hash of valid api routes, from the /configs/apis.js file
 let cache = {};
 let documents = [];
 
@@ -39,15 +40,23 @@ const index = lunr(function () {
     this.field('permalink');
 });
 
-const fetchAPI = function (docParams, cb) {
-    const title = docParams.pageTitlePrefix || docParams.pageTitle;
-    const description = docParams.pageDescription;
-    const githubRepo = docParams.githubRepo || 'yahoo/fluxible';
-    const githubPath = docParams.githubPath;
+/**
+ * Generic function to call GitHub's 'repos' API
+ * https://developer.github.com/v3/repos/
+ *
+ * @function fetchGitHubReposApi
+ * @param {Object} params
+ * @param {String} [params.repo=yahoo/fluxible] Repository
+ * @param {String} params.type Type of data to fetch
+ * @param {Function} cb Request callback function handler
+ * @async
+ */
+function fetchGitHubReposApi(params, cb) {
+    const repo = params.repo || 'yahoo/fluxible';
+    const type = params.type;
 
     // create github api url
-    let githubUrl = 'https://api.github.com/repos/' + githubRepo + '/contents/';
-    githubUrl += githubPath + '?';
+    let githubUrl = 'https://api.github.com/repos/' + repo + '/' + type + '?';
 
     // use access token if available, otherwise use client id and secret
     if (secrets.github.accessToken) {
@@ -61,16 +70,34 @@ const fetchAPI = function (docParams, cb) {
         });
     }
 
-    // add tag from npm version
-    if (docParams.githubTag) {
-        githubUrl += '&ref=' + docParams.githubTag;
+    // the name of the commit/branch/tag
+    if (params.ref) {
+        githubUrl += '&ref=' + params.ref;
     }
     debug(githubUrl);
 
     request
     .get(githubUrl)
     .set('User-Agent', 'superagent')
-    .end(function (err, res) {
+    .end(cb);
+}
+
+/**
+ * Gets the API docs content for fluxible repositories. Runs on an interval
+ * to auto update the docs.
+ *
+ * @function fetchAPI
+ * @param {Object} docParams Properties from route config
+ * @param {Function} cb Async callback function
+ * @async
+ */
+function fetchAPI(docParams, cb) {
+    const title = docParams.pageTitlePrefix || docParams.pageTitle;
+    const description = docParams.pageDescription;
+    const githubRepo = docParams.githubRepo || 'yahoo/fluxible';
+    const githubPath = docParams.githubPath;
+
+    function fetchCallback(err, res) {
         if (err) {
             return cb(err);
         }
@@ -148,10 +175,26 @@ const fetchAPI = function (docParams, cb) {
 
             return cb(null, cache[githubPath]);
         }
-    });
-};
+    }
 
-const fetchNpm = function (pkg, cb) {
+    fetchGitHubReposApi({
+        repo: githubRepo,
+        type: 'contents/' + githubPath,
+        ref: docParams.githubRef
+    }, fetchCallback);
+}
+
+/**
+ * Fetches the npm version for the package given. Then uses that version
+ * to check for matching branches in the libs repo. If found, the branch
+ * is returned otherwise, defaults to `master`.
+ *
+ * @function fetchGitBranch
+ * @param {String} pkg NPM package name
+ * @param {Function} cb Async callback
+ * @async
+ */
+function fetchGitBranch(pkg, cb) {
     var url = 'http://registry.npmjs.org/' + pkg;
     debug(url);
 
@@ -168,40 +211,78 @@ const fetchNpm = function (pkg, cb) {
             version = res.body['dist-tags'].latest;
         }
 
-        cb(null, version);
-    });
-};
+        // after we get the npm version of the package, we need to check and see if there is a
+        // suitable branch on github with the same version. this way we can ensure we receive
+        // the docs for the version published on npm.
+        //
+        // if we do not find a branch, then we default to 'master'.
+        fetchGitHubReposApi({
+            repo: 'yahoo/' + pkg,
+            type: 'branches'
+        }, function (err, res) {
+            if (err || !res) {
+                return cb(new Error('github branches failed for yahoo/' + pkg));
+            }
 
-/*
- Steps
- 1. Call npm API to return version for fluxible and fluxible-addons-react
- 2. Uses these versions to make GitHub API calls for docs content
+            // default to master unless a branch match is found
+            var githubRef = 'master';
+
+            var branches = res.body;
+            branches.forEach(function eachBranch(branch) {
+                var branchName = branch.name;
+
+                // branches start with 'v', need to remove that for semver comparison
+                if (branchName.charAt(0) === 'v') {
+                    branchName = branchName.substr(1);
+                }
+                debug('checking branches for ' + pkg, version, branchName, semver.satisfies(version, branchName));
+
+                // check the cleaned branch name against the version in npm, if the branch
+                // satisifes the version, then use the branch for the github API call
+                if (semver.satisfies(version, branchName)) {
+                    debug('found a branch that matches the npm version', version, branchName);
+                    githubRef = branch.name;
+                }
+            });
+
+            cb(null, githubRef);
+        });
+    });
+}
+
+/**
+ * Gets the API docs content for fluxible repositories. Runs on an interval
+ * to auto update the docs.
+ *
+ * 1. Call npm API to return git branch for fluxible and fluxible-addons-react.
+ * 2. Uses these versions to make GitHub API calls for docs content
+ *
+ * @function refreshCacheFromGithub
  */
 (function refreshCacheFromGithub() {
-    var versionHash = {
+    var branchHash = {
         'yahoo/fluxible': null,
-        'fluxible-addons-react': null
+        'yahoo/fluxible-addons-react': null
     };
     async.auto({
-        fluxibleVersion: function (cb) {
-            fetchNpm('fluxible', cb);
+        fluxibleBranch: function fluxibleBranchCb(cb) {
+            fetchGitBranch('fluxible', cb);
         },
-        fluxibleAddonsVersion: function (cb) {
-            fetchNpm('fluxible-addons-react', cb);
+        fluxibleAddonsBranch: function fluxibleAddonsBranchCb(cb) {
+            fetchGitBranch('fluxible-addons-react', cb);
         },
-        fetchAPI: ['fluxibleVersion', 'fluxibleAddonsVersion', function (cb, results) {
+        fetchApi: ['fluxibleBranch', 'fluxibleAddonsBranch', function fetchApiCb(cb, results) {
             debug('fetchAPI version results', results);
 
             const fetches = [];
-            versionHash['yahoo/fluxible'] = results.fluxibleVersion;
-            versionHash['yahoo/fluxible-addons-react'] = results.fluxibleAddonsVersion;
+            branchHash['yahoo/fluxible'] = results.fluxibleBranch;
+            branchHash['yahoo/fluxible-addons-react'] = results.fluxibleAddonsBranch;
 
             Object.keys(routes).forEach(function eachRoute(routeName) {
                 let routeConfig = routes[routeName];
 
-                // pass npm version depending on repo source to only pull
-                // content for that tag
-                routeConfig.githubTag = 'v' + versionHash[routeConfig.githubRepo];
+                // pass branch name to pull specific branch from github
+                routeConfig.githubRef = branchHash[routeConfig.githubRepo];
 
                 if (routeConfig.githubPath) {
                     fetches.push(function eachTask(cb) {


### PR DESCRIPTION
@lingyan @Vijar @mridgway 

So this cleans up how we get the specific doc content versions from github. Recently, I updated the code to use git tag, but the problem is that anytime we want to update the docs, we need to release a new version of the package. Not ideal.

This PR changes it so that we use the git branch instead. I had to add additional logic to read from 'master' if a matching branch is not found for the version in npm. For example, fluxible-addons-native is on version 0.1.4, it does not have a `v0.1.x` branch, so we need to pull from master.

Also, all these callbacks are getting gross, I want to switch to promises in the next rev :)